### PR TITLE
(PC-25491) fix(ci): use secret manager for sonar token

### DIFF
--- a/.github/workflows/dev_on_pull_request_sonar.yml
+++ b/.github/workflows/dev_on_pull_request_sonar.yml
@@ -13,12 +13,29 @@ jobs:
   sonarcloud:
     name: SonarCloud
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: "OpenID Connect Authentication"
+        uses: 'google-github-actions/auth@v1'
+        with:
+          workload_identity_provider: ${{ secrets.GCP_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_EHP_SERVICE_ACCOUNT }}
+
+      - name: Get Secret
+        id: 'sonar_secrets'
+        uses: 'google-github-actions/get-secretmanager-secrets@v1'
+        with:
+          secrets: |-
+            SONAR_TOKEN:passculture-metier-ehp/passculture-institutional-sonar-token
+
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ steps.sonar_secrets.outputs.SONAR_TOKEN }}


### PR DESCRIPTION
Ticket JIRA : https://passculture.atlassian.net/browse/PC-25491

Cette PR devrait corriger le soucis sur les CI lancées par Dependabot :

* L'action va récupérer le secret sur Secret Manager
* Pour se faire elle va devoir s'authentifier en utilisant workload identity, les infos ont été mises dans les secrets de Dependabot afin que lui aussi soit capable de jouer les actions.

