### PR TITLE
ci: fix add docker build to main workflow

### DIFF
--- a/.github/workflows/reusable_docker_build.yml
+++ b/.github/workflows/reusable_docker_build.yml
@@ -63,6 +63,7 @@ jobs:
         uses: docker/build-push-action@v3.2.0
         with:
           push: ${{ inputs.push }} 
-          tags: ${{ env.DOCKER_REPO }}/${{ inputs.image }}:${{ github.head_ref }},${{ env.DOCKER_REPO }}/${{ inputs.image }}:${{ github.sha }}
+          # Tag with branch name and tag, the variable to get the branch name differs if we are in a pull_request or push event
+          tags: ${{ env.DOCKER_REPO }}/${{ inputs.image }}:${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }},${{ env.DOCKER_REPO }}/${{ inputs.image }}:${{ github.sha }}
           context: ${{ inputs.context }}
 


### PR DESCRIPTION
J'ai oublié que le nom d'une branche quand on fait une PR et quand on push n'est pas le même pour les github actions

