### PR TITLE
ci: add workflow dispatch for testing deployment (PC-26040)

### DIFF
--- a/.github/workflows/on_push_or_dispatch_deploy_testing.yml
+++ b/.github/workflows/on_push_or_dispatch_deploy_testing.yml
@@ -1,4 +1,5 @@
 on: 
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -6,7 +7,7 @@ on:
 name: Deploy testing static website
 
 jobs:
-  deploy-staging:
+  deploy-testing:
     uses: ./.github/workflows/reusable_deploy.yml
     with:
       environment: testing 


### PR DESCRIPTION
On a besoin d'avoir le workflow_dispatch pour le déploiement testing également pour pouvoir le déclencher depuis Strapi.