### PR TITLE
ci: fix docker image tagging on PRs

### DIFF
--- a/.github/workflows/reusable_docker_build.yml
+++ b/.github/workflows/reusable_docker_build.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Get commit hash
         id: get-commit-hash
         run: |
-          HASH="${{ github.event_name == 'pull_request' && github.event.pull_request.head.workflow_runsha || github.sha }}"
+          HASH="${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}"
           echo "HASH=${HASH}" | tee -a ${GITHUB_ENV}
 
       - name: "Build and push ${{ inputs.image }} image"


### PR DESCRIPTION
Lors du build docker dans le cadre d'une PR, le tag donné à l'image docker n'est pas le bon est correspond au commit parent entre les deux branches. Cette PR corrige cela. 
