### PR TITLE
fix: removed unsued env variables from Next

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ The project includes several scripts to simplify development and setup:
 - `yarn audit:all`: Test all the vulnerabilities packages.
 - `yarn test:deadcode`: Test both public_website and content_management_system dead code.
 - `yarn test:deadcode:update`: Update the public_website and content_management_system dead code snapshots.
-- `yarn test:lint:` Test both public_website and content_management_system linting.
-- `yarn test:types:` Test both public_website and content_management_system typing.
+- `yarn test:lint`: Test both public_website and content_management_system linting.
+- `yarn test:types`: Test both public_website and content_management_system typing.
 
 ## Testing
 

--- a/content_management_system/README.md
+++ b/content_management_system/README.md
@@ -1,5 +1,7 @@
 # pass Culture Institutional content management system
 
+You can run Strapi locally, or simply use the instance of Strapi on our testing server (cf [setting environment variables for Next](../public_website/README.md#configure-environment-variables)).
+
 ## Install and configure Postgres
 
 There is a Docker file `docker-compose.yaml` at the root of the project that will create a container for the CMS and another container for Postgres.

--- a/public_website/README.md
+++ b/public_website/README.md
@@ -4,13 +4,11 @@
 
 You will find a template for the environnement variables under `public_website/.env.example`. Duplicate and rename the file `.env`. For running in a local development environnement, you should set `STRAPI_API_URL` to the port Strapi is running on, for example: `http://localhost:1337`.
 
-At the moment, it is not possible to create a build for the website with a non-local instance of the Content Management System. To build locally you must have the CMS running on your own machine.
-
-If you set `STRAPI_API_URL` to a non-local instance of the CMS (for example the testing version: `https://siteinstit-cms.testing.passculture.team`), the token the Public Website needs to access the CMS (Google IAP protected) that is usually provided by the CI will not be found by Next.
+If you set `STRAPI_API_URL` to a non-local instance of the CMS (for example the staging version: `https://siteinstit-cms.staging.passculture.team`), the token the Public Website needs to access the CMS (Google IAP protected) that is usually provided by the CI will not be found by Next. To facilitate development, the token is not required in the testing environnement of the CMS. If you set `STRAPI_API_URL` to `https://siteinstit-cms.staging.passculture.team` you don't have to set `ID_TOKEN`.
 
 > Usually, to access environment variables in the browser, they have to be prefixed by `NEXT_PUBLIC_`. In our case, we only need `STRAPI_API_URL` to be available in the Node.js environment.
 
-There are also 2 environment variables that are used to build the playlists. Since `INSTITUTIONAL_API_KEY` is only available in our CI for security reasons. In consequence, it is not possible locally to get the playlists from our backend. We have included dummy playlist data directly in Next for local development.
+There is also an environment variable that is used to build the playlists. Set `BACKEND_API_URL` to `https://backend.testing.passculture.team/`. We have also included dummy playlist data directly in Next for local development/testing (MSW mocks the playlist data).
 
 ## Start the Public Website
 
@@ -27,7 +25,7 @@ yarn dev
 By default, Next.js will take into account any file ending with tsx, ts, jsx or js under the pages folder for the purpose of building pages/API routes and routing.
 
 We follow Jest's convention by adding tests to the **tests** folder in the project's root directory.
-It is not possible to have the test files along side the page files or the build will fail.
+We have not found an easy way to have the test files along side the page files (the build will fails if tests are included in the `src`).
 
 ## Project Scripts
 

--- a/public_website/__tests__/pages/home.test.tsx
+++ b/public_website/__tests__/pages/home.test.tsx
@@ -10,7 +10,6 @@ describe('Home page', () => {
     process.env = {
       ...process.env,
       ID_TOKEN: 'dummy_token',
-      INSTITUTIONAL_API_KEY: 'dummy_key',
       BACKEND_API_URL: 'http://dummy_localhost:5001/',
     }
   })

--- a/public_website/__tests__/utils/fetchBackend.test.ts
+++ b/public_website/__tests__/utils/fetchBackend.test.ts
@@ -24,49 +24,33 @@ const respondWith = async (
 describe('fetchBackend', () => {
   const OLD_ENV = { ...process.env }
 
-  it('should fail when no key is found', async () => {
+  beforeAll(() => {
     process.env = {
       ...OLD_ENV,
       BACKEND_API_URL: 'http://dummy_localhost:5001/',
     }
+  })
+
+  it('should pass', async () => {
+    const response = await fetchBackend(
+      'institutional/playlist/Bons_plans_du_moment'
+    )
+
+    expect(response).toMatchObject(playlistOffersFixtures)
+  })
+
+  it('should fail if response is not ok', async () => {
+    const statusCode = 500
+    const responseResolver: HttpHandler = http.get(
+      'http://dummy_localhost:5001/institutional/playlist/Bons_plans_du_moment',
+      () => respondWith({}, statusCode)
+    )
+    server.use(responseResolver)
 
     await expect(
       fetchBackend('institutional/playlist/Bons_plans_du_moment')
     ).rejects.toThrow(
-      'Please check if the backend is running and you set all the required tokens. Error: Environnement variable INSTITUTIONAL_API_KEY not found, http://dummy_localhost:5001/institutional/playlist/Bons_plans_du_moment'
+      `Please check if the backend is running and you set all the required tokens. Error: Server returned a non-OK status: ${statusCode}`
     )
-  })
-
-  describe('when key exists', () => {
-    beforeAll(() => {
-      process.env = {
-        ...OLD_ENV,
-        BACKEND_API_URL: 'http://dummy_localhost:5001/',
-        INSTITUTIONAL_API_KEY: 'dummy_key',
-      }
-    })
-
-    it('should pass', async () => {
-      const response = await fetchBackend(
-        'institutional/playlist/Bons_plans_du_moment'
-      )
-
-      expect(response).toMatchObject(playlistOffersFixtures)
-    })
-
-    it('should fail if response is not ok', async () => {
-      const statusCode = 500
-      const responseResolver: HttpHandler = http.get(
-        'http://dummy_localhost:5001/institutional/playlist/Bons_plans_du_moment',
-        () => respondWith({}, statusCode)
-      )
-      server.use(responseResolver)
-
-      await expect(
-        fetchBackend('institutional/playlist/Bons_plans_du_moment')
-      ).rejects.toThrow(
-        `Please check if the backend is running and you set all the required tokens. Error: Server returned a non-OK status: ${statusCode}`
-      )
-    })
   })
 })

--- a/public_website/__tests__/utils/fetchCMS.test.ts
+++ b/public_website/__tests__/utils/fetchCMS.test.ts
@@ -23,10 +23,10 @@ const respondWith = async (
 const OLD_ENV = { ...process.env }
 
 describe('fetchCMS', () => {
-  it('should fail when not in localhost and no token is found', async () => {
+  it('should fail when not in localhost/testing and no token is found', async () => {
     process.env = {
       ...OLD_ENV,
-      STRAPI_API_URL: 'https://siteinstit-cms.testing.passculture.team',
+      STRAPI_API_URL: 'https://siteinstit-cms.staging.passculture.team',
     }
 
     await expect(fetchCMS('/test')).rejects.toThrow(

--- a/public_website/src/utils/fetchBackend.ts
+++ b/public_website/src/utils/fetchBackend.ts
@@ -1,17 +1,10 @@
 export async function fetchBackend(path: string) {
   try {
     const requestUrl = `${process.env['BACKEND_API_URL']}${path}`
-    const key = process.env['INSTITUTIONAL_API_KEY']
-    if (!key) {
-      throw new Error(
-        `Environnement variable INSTITUTIONAL_API_KEY not found, ${requestUrl}`
-      )
-    }
 
     const mergedOptions = {
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${key}`,
       },
     }
 

--- a/public_website/src/utils/fetchCMS.ts
+++ b/public_website/src/utils/fetchCMS.ts
@@ -10,7 +10,11 @@ export async function fetchCMS<T>(path: string) {
     const requestUrl = `${getStrapiURL(apiPath)}`
     const token = process.env['ID_TOKEN']
 
-    if (!requestUrl.includes('localhost') && !token) {
+    if (
+      !requestUrl.includes('localhost') &&
+      !requestUrl.includes('testing') &&
+      !token
+    ) {
       throw new Error('Environnement variable ID_TOKEN not found')
     }
 
@@ -32,7 +36,6 @@ export async function fetchCMS<T>(path: string) {
       const data: HttpResponse<T> = await response.json()
       return data
     } else {
-      // Handle non-JSON responses (e.g., display an error message)
       throw new Error(
         `Unexpected response. Content type received: ${contentType}`
       )


### PR DESCRIPTION
https://passculture.atlassian.net/browse/PC-27773

To test, set .env of Next to:
```
STRAPI_API_URL=https://siteinstit-cms.testing.passculture.team
BACKEND_API_URL=https://backend.testing.passculture.team/
```

Start Next and check if playlist show correctly.