### PR TITLE
fix: use eqi instead of eq to filter latest studies on home page

### DIFF
--- a/public_website/src/pages/index.tsx
+++ b/public_website/src/pages/index.tsx
@@ -107,7 +107,7 @@ export const getStaticProps = (async () => {
     },
     filters: {
       category: {
-        $eq: 'Étude',
+        $eqi: 'Étude',
       },
     },
   })


### PR DESCRIPTION
@Lucasbeneston le fix pour le problème de la home qui ne buildait pas.

Étrangement, lorsqu'on filtre avec l'opérateur `$eq`, ça remonte une 403 tandis qu'avec `$eqi` (case insensitive) ça fonctionne (https://docs.strapi.io/dev-docs/api/rest/filters-locale-publication#filtering). Ça ressemble à un bug côté Strapi et je sais pas l'expliquer mais ça fonctionne.

- Avec `$eq` : https://siteinstit-cms.testing.passculture.team/api/news-list?sort[0]=date%3Adesc&populate[0]=image&pagination[limit]=3&filters[category][$eq]=%C3%89tude
- Avec `$eqi` : https://siteinstit-cms.testing.passculture.team/api/news-list?sort[0]=date%3Adesc&populate[0]=image&pagination[limit]=3&filters[category][$eqi]=%C3%89tude