### PR TITLE
feat(eslint): temporary fix react-hooks/exhaustive-deps warning

### DIFF
--- a/public_website/src/lib/blocks/FilterContainer.tsx
+++ b/public_website/src/lib/blocks/FilterContainer.tsx
@@ -49,6 +49,7 @@ export function FilterContainer({
       newFilterValues[filtre.filtre] = ['']
     })
     setFilterValues(newFilterValues)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filtres])
 
   const handleFilterChange = (event: React.ChangeEvent<HTMLSelectElement>) => {

--- a/public_website/src/pages/liste-jeune.tsx
+++ b/public_website/src/pages/liste-jeune.tsx
@@ -66,6 +66,7 @@ export default function ListeJeune({ newsData, listejeune }: ListProps) {
     })
 
     setFilters(filtres)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const fetchData = async () => {
@@ -108,6 +109,7 @@ export default function ListeJeune({ newsData, listejeune }: ListProps) {
 
   useEffect(() => {
     fetchData()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [category, localisation])
 
   return (


### PR DESCRIPTION
@affo-bien-fonde ou @quentin-bien-fonde ou @adrien-bien-fonde 
Il y a des warning eslint (normalment sur le répo de l'application pass Culture ce sont des erreurs mais nous avons voulu les laisser en warning pour le temps de votre développement), est-ce que vous pouvez voir si ils sont légitimes ou non ? J'ai ignoré les warning ici pour vous montrer ou ça remonte. Je n'ai pas le temps de vérifier si oui ou non il faut modifier les deps des useEffect
 
## 📸 Screenshots

**Delete** _if no UI change_

| Command         | Before | After |
| :---------------- | :-----------: | :---: |
| yarn test:lint  |      <img width="1002" alt="Capture d’écran 2024-03-22 à 12 32 10" src="https://github.com/pass-culture/pass-culture-institutional/assets/62059034/a556efca-a788-4130-9dec-8d3d7e3bbd7d">  |  <img width="1011" alt="Capture d’écran 2024-03-22 à 12 32 22" src="https://github.com/pass-culture/pass-culture-institutional/assets/62059034/a4e72e55-666d-4196-ba15-9448d868ef71"> |