### PR TITLE
refactor(text): add parseTitleWithMarkup

### DIFF
--- a/public_website/__tests__/utils/parseTitleWithMarkup.test.ts
+++ b/public_website/__tests__/utils/parseTitleWithMarkup.test.ts
@@ -5,7 +5,7 @@ import { parseTitleWithMarkup } from '@/utils/parseTitleWithMarkup'
 const title = 'I am a **text** in **bold** very beautiful'
 
 describe('parseTitleWithMarkup', () => {
-  const { textWithMarkup } = parseTitleWithMarkup(title)
+  const { textWithMarkup, accessibilityLabel } = parseTitleWithMarkup(title)
 
   it('should have 5 elements in textWithMarkup', () => {
     expect(textWithMarkup).toHaveLength(5)
@@ -34,8 +34,6 @@ describe('parseTitleWithMarkup', () => {
   })
 
   it('should parse text with markup correctly for accessibilityLabel', () => {
-    const { accessibilityLabel } = parseTitleWithMarkup(title)
-
     expect(accessibilityLabel).toEqual('I am a text in bold very beautiful')
   })
 })

--- a/public_website/__tests__/utils/parseTitleWithMarkup.test.ts
+++ b/public_website/__tests__/utils/parseTitleWithMarkup.test.ts
@@ -16,8 +16,7 @@ describe('parseTitleWithMarkup', () => {
   })
 
   it('second element in textWithMarkup should be a <mark>', () => {
-    // eslint-disable-next-line no-unsafe-optional-chaining
-    expect((textWithMarkup[1]?.type).target).toEqual('mark')
+    expect(textWithMarkup[1]?.type).toEqual('mark')
   })
 
   it('third element in textWithMarkup should be a <span>', () => {
@@ -25,8 +24,7 @@ describe('parseTitleWithMarkup', () => {
   })
 
   it('fourth element in textWithMarkup should be a <mark>', () => {
-    // eslint-disable-next-line no-unsafe-optional-chaining
-    expect((textWithMarkup[3]?.type).target).toEqual('mark')
+    expect(textWithMarkup[3]?.type).toEqual('mark')
   })
 
   it('fifth element in textWithMarkup should be a <span>', () => {

--- a/public_website/__tests__/utils/parseTitleWithMarkup.test.ts
+++ b/public_website/__tests__/utils/parseTitleWithMarkup.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseTitleWithMarkup } from '@/utils/parseTitleWithMarkup'
+
+const title = 'I am a **text** in **bold** very beautiful'
+
+describe('parseTitleWithMarkup', () => {
+  const { textWithMarkup } = parseTitleWithMarkup(title)
+
+  it('should have 5 elements in textWithMarkup', () => {
+    expect(textWithMarkup).toHaveLength(5)
+  })
+
+  it('first element in textWithMarkup should be a <span>', () => {
+    expect(textWithMarkup[0]?.type).toEqual('span')
+  })
+
+  it('second element in textWithMarkup should be a <mark>', () => {
+    // eslint-disable-next-line no-unsafe-optional-chaining
+    expect((textWithMarkup[1]?.type).target).toEqual('mark')
+  })
+
+  it('third element in textWithMarkup should be a <span>', () => {
+    expect(textWithMarkup[2]?.type).toEqual('span')
+  })
+
+  it('fourth element in textWithMarkup should be a <mark>', () => {
+    // eslint-disable-next-line no-unsafe-optional-chaining
+    expect((textWithMarkup[3]?.type).target).toEqual('mark')
+  })
+
+  it('fifth element in textWithMarkup should be a <span>', () => {
+    expect(textWithMarkup[4]?.type).toEqual('span')
+  })
+
+  it('should parse text with markup correctly for accessibilityLabel', () => {
+    const { accessibilityLabel } = parseTitleWithMarkup(title)
+
+    expect(accessibilityLabel).toEqual('I am a text in bold very beautiful')
+  })
+})

--- a/public_website/src/utils/parseTitleWithMarkup.tsx
+++ b/public_website/src/utils/parseTitleWithMarkup.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import styled, { css } from 'styled-components'
+
+export const parseTitleWithMarkup = (
+  text: string
+): { textWithMarkup: JSX.Element[]; accessibilityLabel: string } => {
+  const parts = text.split(/\*\*/)
+  const accessibilityLabel = parts.join('')
+
+  const textWithMarkup = parts.map((part, index) => {
+    if (index % 2 === 1) {
+      return <HighlightedMark key={index}>{part}</HighlightedMark>
+    } else {
+      return <span key={index}>{part}</span>
+    }
+  })
+
+  return { textWithMarkup, accessibilityLabel }
+}
+
+const HighlightedMark = styled.mark`
+  ${({ theme }) => css`
+    background: none;
+    background-image: linear-gradient(
+      to right,
+      ${theme.colors.flashGreen} 50%,
+      ${theme.colors.flashGreen} 50%
+    );
+    background-size: 200% 0.4em;
+    background-position: 100% 90%;
+    background-repeat: no-repeat;
+    color: inherit;
+  `}
+`

--- a/public_website/src/utils/parseTitleWithMarkup.tsx
+++ b/public_website/src/utils/parseTitleWithMarkup.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import styled, { css } from 'styled-components'
 
 export const parseTitleWithMarkup = (
   text: string
@@ -9,7 +8,7 @@ export const parseTitleWithMarkup = (
 
   const textWithMarkup = parts.map((part, index) => {
     if (index % 2 === 1) {
-      return <HighlightedMark key={index}>{part}</HighlightedMark>
+      return <mark key={index}>{part}</mark>
     } else {
       return <span key={index}>{part}</span>
     }
@@ -17,18 +16,3 @@ export const parseTitleWithMarkup = (
 
   return { textWithMarkup, accessibilityLabel }
 }
-
-const HighlightedMark = styled.mark`
-  ${({ theme }) => css`
-    background: none;
-    background-image: linear-gradient(
-      to right,
-      ${theme.colors.flashGreen} 50%,
-      ${theme.colors.flashGreen} 50%
-    );
-    background-size: 200% 0.4em;
-    background-position: 100% 90%;
-    background-repeat: no-repeat;
-    color: inherit;
-  `}
-`

--- a/public_website/src/utils/parseTitleWithMarkup.tsx
+++ b/public_website/src/utils/parseTitleWithMarkup.tsx
@@ -8,9 +8,9 @@ export const parseTitleWithMarkup = (
 
   const textWithMarkup = parts.map((part, index) => {
     if (index % 2 === 1) {
-      return <mark key={index}>{part}</mark>
+      return <mark key={part + index}>{part}</mark>
     } else {
-      return <span key={index}>{part}</span>
+      return <span key={part + index}>{part}</span>
     }
   })
 


### PR DESCRIPTION
Link to JIRA ticket: https://passculture.atlassian.net/browse/PC-29263

Je vais faire une seconde PR pour utiliser `parseTitleWithMarkup`
Parce que je vais devoir modifier tous les textes dans Strapi au merge (je vais le faire en fin de journée pour ne pas gêner)

Utilisation : 
```
      // AVANT 
      <StyledHeading dangerouslySetInnerHTML={{ __html: title }} />
      
      // APRÈS 
      <StyledHeading
        aria-label={parseTitleWithMarkup(new_title).accessibilityLabel}>
        {parseTitleWithMarkup(new_title).textWithMarkup}
      </StyledHeading>
```

Ça fonctionne bien : 
<img width="1728" alt="Capture d’écran 2024-04-22 à 11 54 47" src="https://github.com/pass-culture/pass-culture-institutional/assets/62059034/c606b33b-4748-4908-acc1-7cabd29daadf">


## ✅ Checklist

I have:

- [x] Made sure my feature is **working on different browsers** (Chrome, Firefox, Safari).
- [x] Written **unit tests** for my feature.
- [x] Added a **screenshot** for UI tickets or deleted the screenshot section if no UI change.
