### PR TITLE
fix: added missing onClick for PushCTA

### DIFF
--- a/public_website/src/lib/blocks/PushCTA.tsx
+++ b/public_website/src/lib/blocks/PushCTA.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { useQRCode } from 'next-qrcode'
 import styled, { css } from 'styled-components'
 
+import { onClickAnalytics } from '../analytics/helpers'
 import { theme } from '@/theme/theme'
 import { CTA } from '@/types/CTA'
 import { APIResponse } from '@/types/strapi'
@@ -49,7 +50,14 @@ export function PushCTA(props: PushCTAProps) {
         {props.description && (
           <p dangerouslySetInnerHTML={{ __html: props.description }} />
         )}
-        <CtaLink href={props.ctaLink.URL}>
+        <CtaLink
+          href={props.ctaLink.URL}
+          onClick={() =>
+            onClickAnalytics({
+              eventName: props.ctaLink.eventName,
+              eventOrigin: props.ctaLink.eventOrigin,
+            })
+          }>
           <span>{props.ctaLink.Label}</span>
         </CtaLink>
       </RightSide>


### PR DESCRIPTION
In the `home`, when clicking `Télécharger l'application` , the event `downloadApp` wasn't being sent even if it was correctly filled in Strapi. The issue was that the component being used in strapi was called CTASection, and the data from this component was being used in the Next component `PushCTA` using `CtaLink`. I added an `onClick` calling analytics and it worked.