### PR TITLE
Fix du track du slider dans le simulateur

### DIFF
--- a/content_management_system/src/api/simulator/content-types/simulator/schema.json
+++ b/content_management_system/src/api/simulator/content-types/simulator/schema.json
@@ -117,6 +117,11 @@
       "type": "component",
       "repeatable": false,
       "component": "shared.seo"
+    },
+    "push": {
+      "type": "component",
+      "repeatable": false,
+      "component": "block.simple-push-cta"
     }
   }
 }

--- a/content_management_system/types/generated/contentTypes.d.ts
+++ b/content_management_system/types/generated/contentTypes.d.ts
@@ -1606,6 +1606,7 @@ export interface ApiSimulatorSimulator extends Schema.SingleType {
     socialMedias: Attribute.Component<'block.social-media'> &
       Attribute.Required;
     seo: Attribute.Component<'shared.seo'>;
+    push: Attribute.Component<'block.simple-push-cta'>;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;

--- a/public_website/src/lib/blocks/DetailedLogos.tsx
+++ b/public_website/src/lib/blocks/DetailedLogos.tsx
@@ -28,10 +28,10 @@ export function DetailedLogos({ title, logos }: DetailedLogosProps) {
             <StyledListItem key={logo.title}>
               {logo.image && (
                 <StyledLogoImage
-                  src={logo.image.data.attributes.url}
+                  src={logo?.image?.data?.attributes?.url}
                   alt=""
-                  width={logo.image.data.attributes.width}
-                  height={logo.image.data.attributes.height}
+                  width={logo?.image?.data?.attributes?.width}
+                  height={logo?.image?.data?.attributes?.height}
                 />
               )}
               <StyledLogoHeading>{logo.title}</StyledLogoHeading>

--- a/public_website/src/lib/blocks/DoublePushCta.tsx
+++ b/public_website/src/lib/blocks/DoublePushCta.tsx
@@ -28,8 +28,8 @@ export function DoublePushCTA(props: DoublePushCTAProps) {
     <StyledContentWrapper>
       <MobileImage
         src={
-          props.image?.data.attributes.url &&
-          getStrapiURL(props.image?.data.attributes.url)
+          props.image?.data?.attributes?.url &&
+          getStrapiURL(props.image?.data?.attributes?.url)
         }
         alt=""
       />
@@ -37,8 +37,8 @@ export function DoublePushCTA(props: DoublePushCTAProps) {
         <CardContainer>
           <Card
             $imageUrl={
-              props.image?.data.attributes.url &&
-              getStrapiURL(props.image?.data.attributes.url)
+              props.image?.data?.attributes?.url &&
+              getStrapiURL(props.image?.data?.attributes?.url)
             }></Card>
 
           <OutlinedText shadow>{props.icon}</OutlinedText>

--- a/public_website/src/lib/blocks/Header.tsx
+++ b/public_website/src/lib/blocks/Header.tsx
@@ -34,7 +34,7 @@ export function Header(props: HeaderProps) {
         <CardContainer>
           <Card
             $imageUrl={
-              props.image?.data.attributes.url &&
+              props.image?.data?.attributes?.url &&
               getStrapiURL(props.image?.data.attributes.url)
             }>
             <OutlinedText shadow>{props.icon}</OutlinedText>

--- a/public_website/src/lib/blocks/ImageText.tsx
+++ b/public_website/src/lib/blocks/ImageText.tsx
@@ -37,8 +37,8 @@ export function ImageText({
           $imageOnRight={isImageRight}>
           <ImageContainer $imageOnRight={isImageRight}>
             <StyledImage
-              src={getStrapiURL(image?.data.attributes.url)}
-              alt={image?.data.attributes.alternativeText || ''}
+              src={getStrapiURL(image?.data?.attributes?.url)}
+              alt={image?.data?.attributes?.alternativeText || ''}
             />
             {icon && (
               <StyledIcon className={isImageRight ? 'IconRight' : 'IconLeft'}>

--- a/public_website/src/lib/blocks/PiledCards/PiledCards.tsx
+++ b/public_website/src/lib/blocks/PiledCards/PiledCards.tsx
@@ -77,8 +77,8 @@ export function PiledCards(props: PiledCardsProps) {
               aria-label={`Card ${index + 1}`}>
               <StyledImageWrapper>
                 <StyledImage
-                  src={item.image?.data.attributes.url}
-                  alt={item.image?.data.attributes.alternativeText}
+                  src={item.image?.data?.attributes?.url}
+                  alt={item.image?.data?.attributes?.alternativeText}
                 />
                 <StyledFirstEmoji aria-hidden="true">
                   <OutlinedText blurDeviation={1}>

--- a/public_website/src/lib/blocks/PiledCards/PiledCardsCarouselSlide.tsx
+++ b/public_website/src/lib/blocks/PiledCards/PiledCardsCarouselSlide.tsx
@@ -25,7 +25,7 @@ export function VerticalCarouselSlide({
   theme,
 }: PiledCardsCarouselSlideProps) {
   const imageUrl =
-    typeof image === 'string' ? image : image?.data.attributes.url
+    typeof image === 'string' ? image : image?.data?.attributes?.url
 
   const [descriptionIsOpen, setDescriptionIsOpen] = useState(false)
 

--- a/public_website/src/lib/blocks/PushCTA.tsx
+++ b/public_website/src/lib/blocks/PushCTA.tsx
@@ -29,8 +29,8 @@ export function PushCTA(props: PushCTAProps) {
       <CardContainer>
         <Card
           $imageUrl={
-            props.image?.data?.attributes.url &&
-            getStrapiURL(props.image?.data.attributes.url)
+            props.image?.data?.attributes?.url &&
+            getStrapiURL(props.image?.data?.attributes?.url)
           }>
           <QRCodeCard>
             <QrCode

--- a/public_website/src/lib/blocks/SimplePushCta.tsx
+++ b/public_website/src/lib/blocks/SimplePushCta.tsx
@@ -44,8 +44,8 @@ export function SimplePushCta(props: PushCTAProps) {
         <CardContainer>
           <Card
             $imageUrl={
-              props.image?.data.attributes.url &&
-              getStrapiURL(props.image?.data.attributes.url)
+              props.image?.data?.attributes?.url &&
+              getStrapiURL(props.image?.data?.attributes?.url)
             }></Card>
           <OutlinedText>{props.icon}</OutlinedText>
         </CardContainer>

--- a/public_website/src/lib/blocks/Video.tsx
+++ b/public_website/src/lib/blocks/Video.tsx
@@ -28,7 +28,7 @@ export function Video(props: VideoProps) {
           <StyledVideo
             light={
               props.image
-                ? getStrapiURL(props.image?.data.attributes.url)
+                ? getStrapiURL(props.image?.data?.attributes?.url)
                 : true
             }
             url={props.url}

--- a/public_website/src/lib/blocks/experienceVideoCarousel/experieneVideoCarouselSlide.tsx
+++ b/public_website/src/lib/blocks/experienceVideoCarousel/experieneVideoCarouselSlide.tsx
@@ -41,7 +41,7 @@ export function ExperienceVideoCarouselSlide({
           isMounted &&
           (url ? (
             <StyledExperienceVideo
-              light={image ? getStrapiURL(image?.data.attributes.url) : true}
+              light={image ? getStrapiURL(image?.data?.attributes?.url) : true}
               url={url}
               width="100%"
               controls={false}
@@ -52,7 +52,7 @@ export function ExperienceVideoCarouselSlide({
           ) : (
             <StyledExperienceVideo
               as="img"
-              src={getStrapiURL(image.data.attributes.url)}
+              src={getStrapiURL(image?.data?.attributes?.url)}
               alt=""
             />
           ))}

--- a/public_website/src/lib/blocks/logoCarousel/logoCarousel.tsx
+++ b/public_website/src/lib/blocks/logoCarousel/logoCarousel.tsx
@@ -100,7 +100,7 @@ export function LogoCarousel({ items }: LogoCarouselProps) {
         {items?.map((item, index) => {
           return (
             <LogoCarouselSlide
-              key={item.logo?.data.attributes.alternativeText}
+              key={item.logo?.data?.attributes?.alternativeText}
               slideIndex={index}
               {...item}
               image={item.logo}
@@ -127,11 +127,11 @@ export function LogoCarousel({ items }: LogoCarouselProps) {
           return (
             <StyledDot
               onClick={handleNavigationButtonClick}
-              key={item.logo?.data.attributes.alternativeText}
+              key={item.logo?.data?.attributes?.alternativeText}
               slide={index}
               aria-label={`Afficher la diapositive ${index + 1} sur ${
                 items.length
-              } : ${item.logo?.data.attributes.alternativeText}`}
+              } : ${item.logo?.data?.attributes?.alternativeText}`}
             />
           )
         })}

--- a/public_website/src/lib/blocks/logoCarousel/logoCarouselSlide.tsx
+++ b/public_website/src/lib/blocks/logoCarousel/logoCarouselSlide.tsx
@@ -17,13 +17,13 @@ export function LogoCarouselSlide({
   return (
     <Root
       index={slideIndex}
-      key={image?.data.attributes.alternativeText}
+      key={image?.data?.attributes?.alternativeText}
       innerClassName="inner"
       aria-roledescription="diapositive">
       <StyledLink>
         <StyledImageSimple
-          alt={image?.data.attributes.alternativeText}
-          src={getStrapiURL(image?.data.attributes.url)}></StyledImageSimple>
+          alt={image?.data?.attributes?.alternativeText}
+          src={getStrapiURL(image?.data?.attributes?.url)}></StyledImageSimple>
       </StyledLink>
     </Root>
   )

--- a/public_website/src/lib/blocks/verticalCarousel/VerticalCarouselSlide.tsx
+++ b/public_website/src/lib/blocks/verticalCarousel/VerticalCarouselSlide.tsx
@@ -27,7 +27,7 @@ export function VerticalCarouselSlide({
   hidePlayIcon,
 }: VerticalCarouselSlideProps) {
   const imageUrl =
-    typeof image === 'string' ? image : image?.data?.attributes.url
+    typeof image === 'string' ? image : image?.data?.attributes?.url
 
   return (
     <Root

--- a/public_website/src/ui/components/simulator/SliderField.tsx
+++ b/public_website/src/ui/components/simulator/SliderField.tsx
@@ -91,7 +91,7 @@ export function SliderField({
             </span>
           ),
         }}
-        included={false}
+        included
         ariaValueTextFormatterForHandle={valueTextFormatter}
         value={(answer ?? 0) + 14}
         onChange={handleChange}
@@ -181,9 +181,12 @@ const Slider = styled(BaseSlider)`
   .rc-slider-dot {
     opacity: 0;
   }
+  .rc-slider-track {
+    background-color: ${({ theme }) => theme.colors.primary};
+    height: 0.5rem;
+  }
 
   .rc-slider-rail {
-    background-color: ${({ theme }) => theme.colors.primary};
     height: 0.5rem;
   }
 


### PR DESCRIPTION
## Fix du track du slider dans le simulateur.

### Description
Avant correction:
Quand on est au point de départ du simulateur, la jauge ne doit pas être rempli en violet.
Après correction:
La jauge se remplie selon la position du curseur.

### Changements
Changement de la props inluded (false à true) du composant Slider  dans le composant SliderField.tsx et ajustement css pour la classe rc-slider-track.

### Ticket Notion
[Ticket sur notion.](https://www.notion.so/quand-on-est-au-point-de-d-part-du-simulateur-la-jauge-ne-doit-pas-etre-rempli-en-violet-cf-maquet-8744c9e3d4f446dd99ffe12c0093706b?pvs=4)



