### PR TITLE
Fix button focus

### DIFF
--- a/content_management_system/src/components/block/simple-text-v2.json
+++ b/content_management_system/src/components/block/simple-text-v2.json
@@ -8,7 +8,7 @@
   "attributes": {
     "title": {
       "type": "string",
-      "required": false
+      "required": true
     },
     "text": {
       "type": "blocks",

--- a/content_management_system/src/components/common/simple-text-column.json
+++ b/content_management_system/src/components/common/simple-text-column.json
@@ -1,7 +1,8 @@
 {
   "collectionName": "components_common_simple_text_columns",
   "info": {
-    "displayName": "Simple Text Column"
+    "displayName": "Simple Text Column",
+    "description": ""
   },
   "options": {},
   "attributes": {

--- a/content_management_system/types/generated/components.d.ts
+++ b/content_management_system/types/generated/components.d.ts
@@ -352,7 +352,7 @@ export interface BlockSimpleTextV2 extends Schema.Component {
     description: '';
   };
   attributes: {
-    title: Attribute.String;
+    title: Attribute.String & Attribute.Required;
     text: Attribute.Blocks & Attribute.Required;
     columns: Attribute.Component<'common.simple-text-column', true> &
       Attribute.SetMinMax<{
@@ -641,6 +641,7 @@ export interface CommonSimpleTextColumn extends Schema.Component {
   collectionName: 'components_common_simple_text_columns';
   info: {
     displayName: 'Simple Text Column';
+    description: '';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;

--- a/public_website/src/lib/blocks/DetailedLogos.tsx
+++ b/public_website/src/lib/blocks/DetailedLogos.tsx
@@ -28,10 +28,10 @@ export function DetailedLogos({ title, logos }: DetailedLogosProps) {
             <StyledListItem key={logo.title}>
               {logo.image && (
                 <StyledLogoImage
-                  src={logo.image.data.attributes.url}
+                  src={logo?.image?.data?.attributes?.url}
                   alt=""
-                  width={logo.image.data.attributes.width}
-                  height={logo.image.data.attributes.height}
+                  width={logo?.image?.data?.attributes?.width}
+                  height={logo?.image?.data?.attributes?.height}
                 />
               )}
               <StyledLogoHeading>{logo.title}</StyledLogoHeading>

--- a/public_website/src/lib/blocks/DoublePushCta.tsx
+++ b/public_website/src/lib/blocks/DoublePushCta.tsx
@@ -28,8 +28,8 @@ export function DoublePushCTA(props: DoublePushCTAProps) {
     <StyledContentWrapper>
       <MobileImage
         src={
-          props.image?.data.attributes.url &&
-          getStrapiURL(props.image?.data.attributes.url)
+          props.image?.data?.attributes?.url &&
+          getStrapiURL(props.image?.data?.attributes?.url)
         }
         alt=""
       />
@@ -37,8 +37,8 @@ export function DoublePushCTA(props: DoublePushCTAProps) {
         <CardContainer>
           <Card
             $imageUrl={
-              props.image?.data.attributes.url &&
-              getStrapiURL(props.image?.data.attributes.url)
+              props.image?.data?.attributes?.url &&
+              getStrapiURL(props.image?.data?.attributes?.url)
             }></Card>
 
           <OutlinedText shadow>{props.icon}</OutlinedText>

--- a/public_website/src/lib/blocks/Header.tsx
+++ b/public_website/src/lib/blocks/Header.tsx
@@ -34,7 +34,7 @@ export function Header(props: HeaderProps) {
         <CardContainer>
           <Card
             $imageUrl={
-              props.image?.data.attributes.url &&
+              props.image?.data?.attributes?.url &&
               getStrapiURL(props.image?.data.attributes.url)
             }>
             <OutlinedText shadow>{props.icon}</OutlinedText>

--- a/public_website/src/lib/blocks/ImageText.tsx
+++ b/public_website/src/lib/blocks/ImageText.tsx
@@ -37,8 +37,8 @@ export function ImageText({
           $imageOnRight={isImageRight}>
           <ImageContainer $imageOnRight={isImageRight}>
             <StyledImage
-              src={getStrapiURL(image?.data.attributes.url)}
-              alt={image?.data.attributes.alternativeText || ''}
+              src={getStrapiURL(image?.data?.attributes?.url)}
+              alt={image?.data?.attributes?.alternativeText || ''}
             />
             {icon && (
               <StyledIcon className={isImageRight ? 'IconRight' : 'IconLeft'}>

--- a/public_website/src/lib/blocks/PiledCards/PiledCards.tsx
+++ b/public_website/src/lib/blocks/PiledCards/PiledCards.tsx
@@ -77,8 +77,8 @@ export function PiledCards(props: PiledCardsProps) {
               aria-label={`Card ${index + 1}`}>
               <StyledImageWrapper>
                 <StyledImage
-                  src={item.image?.data.attributes.url}
-                  alt={item.image?.data.attributes.alternativeText}
+                  src={item.image?.data?.attributes?.url}
+                  alt={item.image?.data?.attributes?.alternativeText}
                 />
                 <StyledFirstEmoji aria-hidden="true">
                   <OutlinedText blurDeviation={1}>

--- a/public_website/src/lib/blocks/PiledCards/PiledCardsCarouselSlide.tsx
+++ b/public_website/src/lib/blocks/PiledCards/PiledCardsCarouselSlide.tsx
@@ -25,7 +25,7 @@ export function VerticalCarouselSlide({
   theme,
 }: PiledCardsCarouselSlideProps) {
   const imageUrl =
-    typeof image === 'string' ? image : image?.data.attributes.url
+    typeof image === 'string' ? image : image?.data?.attributes?.url
 
   const [descriptionIsOpen, setDescriptionIsOpen] = useState(false)
 

--- a/public_website/src/lib/blocks/PushCTA.tsx
+++ b/public_website/src/lib/blocks/PushCTA.tsx
@@ -29,8 +29,8 @@ export function PushCTA(props: PushCTAProps) {
       <CardContainer>
         <Card
           $imageUrl={
-            props.image?.data?.attributes.url &&
-            getStrapiURL(props.image?.data.attributes.url)
+            props.image?.data?.attributes?.url &&
+            getStrapiURL(props.image?.data?.attributes?.url)
           }>
           <QRCodeCard>
             <QrCode

--- a/public_website/src/lib/blocks/SimplePushCta.tsx
+++ b/public_website/src/lib/blocks/SimplePushCta.tsx
@@ -226,7 +226,7 @@ const CtaLink = styled(Link)`
     &:hover {
       background: ${`rgba(255, 255, 255, 0.20);`};
     }
-    &:focus {
+    &:active {
       outline: 2px solid ${theme.colors.white};
     }
     color: ${theme.colors.white};

--- a/public_website/src/lib/blocks/SimplePushCta.tsx
+++ b/public_website/src/lib/blocks/SimplePushCta.tsx
@@ -44,8 +44,8 @@ export function SimplePushCta(props: PushCTAProps) {
         <CardContainer>
           <Card
             $imageUrl={
-              props.image?.data.attributes.url &&
-              getStrapiURL(props.image?.data.attributes.url)
+              props.image?.data?.attributes?.url &&
+              getStrapiURL(props.image?.data?.attributes?.url)
             }></Card>
           <OutlinedText>{props.icon}</OutlinedText>
         </CardContainer>

--- a/public_website/src/lib/blocks/Video.tsx
+++ b/public_website/src/lib/blocks/Video.tsx
@@ -28,7 +28,7 @@ export function Video(props: VideoProps) {
           <StyledVideo
             light={
               props.image
-                ? getStrapiURL(props.image?.data.attributes.url)
+                ? getStrapiURL(props.image?.data?.attributes?.url)
                 : true
             }
             url={props.url}

--- a/public_website/src/lib/blocks/experienceVideoCarousel/experieneVideoCarouselSlide.tsx
+++ b/public_website/src/lib/blocks/experienceVideoCarousel/experieneVideoCarouselSlide.tsx
@@ -41,7 +41,7 @@ export function ExperienceVideoCarouselSlide({
           isMounted &&
           (url ? (
             <StyledExperienceVideo
-              light={image ? getStrapiURL(image?.data.attributes.url) : true}
+              light={image ? getStrapiURL(image?.data?.attributes?.url) : true}
               url={url}
               width="100%"
               controls={false}
@@ -52,7 +52,7 @@ export function ExperienceVideoCarouselSlide({
           ) : (
             <StyledExperienceVideo
               as="img"
-              src={getStrapiURL(image.data.attributes.url)}
+              src={getStrapiURL(image?.data?.attributes?.url)}
               alt=""
             />
           ))}

--- a/public_website/src/lib/blocks/logoCarousel/logoCarousel.tsx
+++ b/public_website/src/lib/blocks/logoCarousel/logoCarousel.tsx
@@ -100,7 +100,7 @@ export function LogoCarousel({ items }: LogoCarouselProps) {
         {items?.map((item, index) => {
           return (
             <LogoCarouselSlide
-              key={item.logo?.data.attributes.alternativeText}
+              key={item.logo?.data?.attributes?.alternativeText}
               slideIndex={index}
               {...item}
               image={item.logo}
@@ -127,11 +127,11 @@ export function LogoCarousel({ items }: LogoCarouselProps) {
           return (
             <StyledDot
               onClick={handleNavigationButtonClick}
-              key={item.logo?.data.attributes.alternativeText}
+              key={item.logo?.data?.attributes?.alternativeText}
               slide={index}
               aria-label={`Afficher la diapositive ${index + 1} sur ${
                 items.length
-              } : ${item.logo?.data.attributes.alternativeText}`}
+              } : ${item.logo?.data?.attributes?.alternativeText}`}
             />
           )
         })}

--- a/public_website/src/lib/blocks/logoCarousel/logoCarouselSlide.tsx
+++ b/public_website/src/lib/blocks/logoCarousel/logoCarouselSlide.tsx
@@ -17,13 +17,13 @@ export function LogoCarouselSlide({
   return (
     <Root
       index={slideIndex}
-      key={image?.data.attributes.alternativeText}
+      key={image?.data?.attributes?.alternativeText}
       innerClassName="inner"
       aria-roledescription="diapositive">
       <StyledLink>
         <StyledImageSimple
-          alt={image?.data.attributes.alternativeText}
-          src={getStrapiURL(image?.data.attributes.url)}></StyledImageSimple>
+          alt={image?.data?.attributes?.alternativeText}
+          src={getStrapiURL(image?.data?.attributes?.url)}></StyledImageSimple>
       </StyledLink>
     </Root>
   )

--- a/public_website/src/lib/blocks/verticalCarousel/VerticalCarouselSlide.tsx
+++ b/public_website/src/lib/blocks/verticalCarousel/VerticalCarouselSlide.tsx
@@ -27,7 +27,7 @@ export function VerticalCarouselSlide({
   hidePlayIcon,
 }: VerticalCarouselSlideProps) {
   const imageUrl =
-    typeof image === 'string' ? image : image?.data?.attributes.url
+    typeof image === 'string' ? image : image?.data?.attributes?.url
 
   return (
     <Root

--- a/public_website/src/ui/components/button/Button.tsx
+++ b/public_website/src/ui/components/button/Button.tsx
@@ -92,7 +92,7 @@ const StyledButton = styled.button<{ $variant: ButtonVariants }>`
     ${$variant === 'quaternary' && `border: 1px solid ${theme.colors.purple};`}
     outline-offset: 2px;
     transition: all 0.4s ease-in-out;
-    &:focus {
+    &:active {
       ${$variant === 'tertiary' &&
       `background:rgba(255,255,255,0);
         color:${theme.colors.white};`}


### PR DESCRIPTION
## Fix button focus

### Description
Un outline restait affiché  une fois le clique effectué en raison du focus mis sur les buttons (Button.tsx et SimplePushCta.tsx). 
Cette pull request corrige donc ce focus en modifiant la pseudo classe focus en active.

### Changements
La pseudo classe focus est devenu une pseudo classe active du CtaLink et StyledButton.

### Ticket
La correction fait référence à la demande [ici](https://www.notion.so/tous-les-boutons-de-ce-gabarit-Quand-je-clique-dessus-le-contour-apparait-au-click-mais-quand-je-r-ed64e771237d441e8f9543d13d1647fb?pvs=4).

