### PR TITLE
fix(SliderField): simulateur jauge

### DIFF
--- a/public_website/src/ui/components/simulator/SliderField.tsx
+++ b/public_website/src/ui/components/simulator/SliderField.tsx
@@ -22,8 +22,6 @@ export function SliderField({
   title,
   answer,
 }: SliderFieldProps) {
-
-
   const [isClient, setIsClient] = useState<boolean>(false)
 
   const valueTextFormatter: AriaValueFormat = useCallback(
@@ -110,7 +108,7 @@ export function SliderField({
             id="question-field"
             value={answer}
             onChange={(e) => onChange(Number(e.target.value))}>
-            {answers.map((a:string, i:number) => (
+            {answers.map((a: string, i: number) => (
               <option
                 key={a}
                 value={i}
@@ -167,7 +165,6 @@ const Slider = styled(BaseSlider)`
       background-color: ${({ theme }) => theme.colors.primary};
       opacity: 0.1;
     }
-
     &:last-of-type {
       width: max-content;
       transform: translateX(-100%) !important;
@@ -177,7 +174,6 @@ const Slider = styled(BaseSlider)`
         right: 0;
       }
     }
-
     &:first-of-type {
       width: max-content;
       transform: translateX(0) !important;
@@ -187,7 +183,6 @@ const Slider = styled(BaseSlider)`
       }
     }
   }
-
   .rc-slider-dot {
     opacity: 0;
   }
@@ -199,7 +194,6 @@ const Slider = styled(BaseSlider)`
     background-color: ${({ theme }) => theme.colors.primary};
     height: 0.5rem;
   }
-
   .rc-slider-handle {
     background-color: ${({ theme }) => theme.colors.primary};
     width: 2rem;
@@ -231,7 +225,6 @@ const SelectWrapper = styled.div`
 
 const Select = styled.select`
   padding: 1.25rem 1.875rem;
-
   font-size: ${({ theme }) => theme.fonts.sizes.s};
   font-weight: ${({ theme }) => theme.fonts.weights.bold};
   line-height: 2;

--- a/public_website/src/ui/components/simulator/SliderField.tsx
+++ b/public_website/src/ui/components/simulator/SliderField.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { default as BaseSlider } from 'rc-slider'
 import type { AriaValueFormat } from 'rc-slider/lib/interface'
 import styled, { css } from 'styled-components'
@@ -22,6 +22,10 @@ export function SliderField({
   title,
   answer,
 }: SliderFieldProps) {
+
+
+  const [isClient, setIsClient] = useState<boolean>(false)
+
   const valueTextFormatter: AriaValueFormat = useCallback(
     (value: number) => {
       if (value <= 14) {
@@ -48,6 +52,10 @@ export function SliderField({
     },
     [onChange]
   )
+
+  useEffect(() => {
+    setIsClient(true)
+  }, [])
 
   return (
     <Field>
@@ -91,25 +99,27 @@ export function SliderField({
             </span>
           ),
         }}
-        included={false}
+        included
         ariaValueTextFormatterForHandle={valueTextFormatter}
         value={(answer ?? 0) + 14}
         onChange={handleChange}
       />
       <SelectWrapper>
-        <Select
-          id="question-field"
-          value={answer}
-          onChange={(e) => onChange(Number(e.target.value))}>
-          {answers.map((a, i) => (
-            <option
-              key={a}
-              value={i}
-              aria-label={parseText(a!).accessibilityLabel}>
-              {parseText(a!).processedText}
-            </option>
-          ))}
-        </Select>
+        {isClient && (
+          <Select
+            id="question-field"
+            value={answer}
+            onChange={(e) => onChange(Number(e.target.value))}>
+            {answers.map((a:string, i:number) => (
+              <option
+                key={a}
+                value={i}
+                aria-label={parseText(a).accessibilityLabel}>
+                {parseText(a).processedText}
+              </option>
+            ))}
+          </Select>
+        )}
         <SelectIcon />
       </SelectWrapper>
     </Field>
@@ -183,6 +193,9 @@ const Slider = styled(BaseSlider)`
   }
 
   .rc-slider-rail {
+    height: 0.5rem;
+  }
+  .rc-slider-track {
     background-color: ${({ theme }) => theme.colors.primary};
     height: 0.5rem;
   }


### PR DESCRIPTION
## Description
Avant correction:
Quand on est au point de départ du simulateur, la jauge ne doit pas être rempli en violet.
Après correction:
La jauge se remplie selon la position du curseur.

D'autre part, il pourvait y avoir un soucis d'hydratation avec le select. Un state a été ajouté pour afficher le select coté client pour corriger le soucis.

## Changements
Changement de la props inluded (false à true) du composant Slider dans le composant SliderField.tsx et ajustement css pour la classe rc-slider-track.

## Ticket Notion
[Ticket sur notion.](https://www.notion.so/quand-on-est-au-point-de-d-part-du-simulateur-la-jauge-ne-doit-pas-etre-rempli-en-violet-cf-maquet-8744c9e3d4f446dd99ffe12c0093706b?pvs=4)
