### PR TITLE
fix: focus boutton

### DIFF
--- a/public_website/src/lib/blocks/SimplePushCta.tsx
+++ b/public_website/src/lib/blocks/SimplePushCta.tsx
@@ -226,7 +226,7 @@ const CtaLink = styled(Link)`
     &:hover {
       background: ${`rgba(255, 255, 255, 0.20);`};
     }
-    &:focus {
+    &:active {
       outline: 2px solid ${theme.colors.white};
     }
     color: ${theme.colors.white};

--- a/public_website/src/ui/components/button/Button.tsx
+++ b/public_website/src/ui/components/button/Button.tsx
@@ -92,7 +92,7 @@ const StyledButton = styled.button<{ $variant: ButtonVariants }>`
     ${$variant === 'quaternary' && `border: 1px solid ${theme.colors.purple};`}
     outline-offset: 2px;
     transition: all 0.4s ease-in-out;
-    &:focus {
+    &:active {
       ${$variant === 'tertiary' &&
       `background:rgba(255,255,255,0);
         color:${theme.colors.white};`}


### PR DESCRIPTION
## Description
Un outline restait affiché une fois le clique effectué en raison du focus mis sur les buttons (Button.tsx et SimplePushCta.tsx).
Cette pull request corrige donc ce focus en modifiant la pseudo classe focus en active.

## Changements
La pseudo classe focus est devenu une pseudo classe active du CtaLink et StyledButton.

## Ticket
La correction fait référence à la demande [ici](https://www.notion.so/tous-les-boutons-de-ce-gabarit-Quand-je-clique-dessus-le-contour-apparait-au-click-mais-quand-je-r-ed64e771237d441e8f9543d13d1647fb?pvs=4).