### PR TITLE
fix: active les items dans le menu et le megamenu selon la route

### DIFF
--- a/public_website/src/ui/components/header/MegaMenu.tsx
+++ b/public_website/src/ui/components/header/MegaMenu.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react'
+import { useRouter } from 'next/router'
 import styled, { css } from 'styled-components'
 
 import { AppBanner } from '../app-banner/AppBanner'
@@ -9,6 +10,7 @@ import { onClickAnalytics } from '@/lib/analytics/helpers'
 import { CTA } from '@/types/CTA'
 import { Link } from '@/ui/components/Link'
 import { parseText } from '@/utils/parseText'
+import { isStringAreEquals } from '@/utils/stringAreEquals'
 
 type MegaMenuProps = {
   onBlur: () => void
@@ -43,6 +45,7 @@ export function MegaMenu({
   data,
 }: MegaMenuProps) {
   const megaMenuRef = useRef<HTMLDivElement>(null)
+  const path = useRouter().asPath
 
   function onClickOutside(e: MouseEvent) {
     if (!megaMenuRef.current?.contains(e.target as HTMLElement)) {
@@ -104,6 +107,9 @@ export function MegaMenu({
               return (
                 <li key={item.Label}>
                   <Link
+                    className={
+                      isStringAreEquals(path, item.URL) ? 'active' : ''
+                    }
                     href={item.URL}
                     aria-label={parseText(item.Label).accessibilityLabel}>
                     {parseText(item.Label).processedText}
@@ -117,6 +123,9 @@ export function MegaMenu({
               return (
                 <li key={item.Label}>
                   <Link
+                    className={
+                      isStringAreEquals(path, item.URL.trim()) ? 'active' : ''
+                    }
                     href={item.URL}
                     aria-label={parseText(item.Label).accessibilityLabel}>
                     {parseText(item.Label).processedText}
@@ -207,7 +216,9 @@ const StyledMegaMenuLists = styled.div`
       font-weight: ${theme.fonts.weights.semiBold};
       color: ${theme.colors.black};
       opacity: 0.9;
-
+      &.active {
+        text-decoration: underline;
+      }
       &:hover {
         text-decoration: underline;
       }

--- a/public_website/src/utils/stringAreEquals.ts
+++ b/public_website/src/utils/stringAreEquals.ts
@@ -1,0 +1,5 @@
+export const isStringAreEquals = (str1: string, str2: string): boolean => {
+  if (str1.trim().toLocaleLowerCase() === str2.trim().toLocaleLowerCase())
+    return true
+  return false
+}


### PR DESCRIPTION
## Description
Cette pull request règle le problème des items actifs du menu (header et megamenu). Lorsque l'on navigue sur une page fille, l'item du menu de la page parent doit être actif, ainsi que l'item du megamenu de la page fille.

## Changement
Deux fonctions findCollectionIdByPath et. findInMenu ont été écrites dans Header.tsx pour faire matcher la route active et l'item du menu.
Une classe active a été ajoutée dans sur les link dans MegaMenu.tsx.
Une fonction utile qui compare deux chaînes de string a été écrite (isStringAreEquals)
Issue relative
Notion [ici](https://www.notion.so/normalement-quand-on-est-sur-une-page-fille-par-exemple-jeunes-ou-parents-les-offres-dans-la-nav-53819d89d344444fa54e0af39f73f892?pvs=4).

## Note
Il est à noter que si coté back des espaces vides sont laissées en fin d'url, ceux-ci remontent en front. Un "trim" a donc été ajouté dans le traitement des url dans findCollectionIdByPath.