### PR TITLE
fix: fil arianne

### DIFF
--- a/public_website/src/pages/[...slug].tsx
+++ b/public_website/src/pages/[...slug].tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 import { BlockRenderer } from '@/lib/BlockRenderer'
 import { Seo } from '@/lib/seo/seo'
 import { APIResponseData } from '@/types/strapi'
+import { Breadcrumb } from '@/ui/components/breadcrumb/Breadcrumb'
 import { fetchCMS } from '@/utils/fetchCMS'
 
 interface CustomPageProps {
@@ -13,14 +14,28 @@ interface CustomPageProps {
 }
 
 export default function CustomPage(props: CustomPageProps) {
+  const { seo, Blocks } = props.data.attributes
+
   return (
     <PageWrapper>
-      {props.data.attributes.seo && (
-        <Seo metaData={props.data.attributes.seo} />
-      )}
-      {props.data.attributes.Blocks?.map((block) => (
-        <BlockRenderer key={`${block.__component}_${block.id}`} block={block} />
-      ))}
+      {seo && <Seo metaData={props.data.attributes.seo} />}
+
+      {Blocks?.map((block, index) => {
+        return index === 1 ? (
+          <React.Fragment key={`${block.__component}_${block.id}`}>
+            <Breadcrumb isUnderHeader />
+            <BlockRenderer
+              key={`${block.__component}_${block.id}`}
+              block={block}
+            />
+          </React.Fragment>
+        ) : (
+          <BlockRenderer
+            key={`${block.__component}_${block.id}`}
+            block={block}
+          />
+        )
+      })}
     </PageWrapper>
   )
 }

--- a/public_website/src/pages/[...slug].tsx
+++ b/public_website/src/pages/[...slug].tsx
@@ -18,7 +18,7 @@ export default function CustomPage(props: CustomPageProps) {
 
   return (
     <PageWrapper>
-      {seo && <Seo metaData={props.data.attributes.seo} />}
+      {seo && <Seo metaData={seo} />}
 
       {Blocks?.map((block, index) => {
         return index === 1 ? (

--- a/public_website/src/pages/[...slug].tsx
+++ b/public_website/src/pages/[...slug].tsx
@@ -19,21 +19,19 @@ export default function CustomPage(props: CustomPageProps) {
   return (
     <PageWrapper>
       {seo && <Seo metaData={seo} />}
-
       {Blocks?.map((block, index) => {
-        return index === 1 ? (
-          <React.Fragment key={`${block.__component}_${block.id}`}>
-            <Breadcrumb isUnderHeader />
-            <BlockRenderer
-              key={`${block.__component}_${block.id}`}
-              block={block}
-            />
-          </React.Fragment>
-        ) : (
+        const blockContent = (
           <BlockRenderer
             key={`${block.__component}_${block.id}`}
             block={block}
           />
+        )
+        return index === 1 ? (
+          <React.Fragment key={`${block.__component}_${block.id}`}>
+            <Breadcrumb isUnderHeader /> {blockContent}
+          </React.Fragment>
+        ) : (
+          blockContent
         )
       })}
     </PageWrapper>

--- a/public_website/src/ui/components/breadcrumb/Breadcrumb.tsx
+++ b/public_website/src/ui/components/breadcrumb/Breadcrumb.tsx
@@ -6,6 +6,7 @@ import styled, { css } from 'styled-components'
 import { ContentWrapper } from '../ContentWrapper'
 import { ChevronDown } from '../icons/ChevronDown'
 import { BreadcrumbContext } from './breadcrumb-context'
+import { isStringAreEquals } from '@/utils/stringAreEquals'
 
 interface BreadcrumbProps {
   isUnderHeader?: boolean
@@ -21,13 +22,15 @@ export function Breadcrumb(props: BreadcrumbProps) {
     return null
   }
 
-  const currentNavigationGroup = headerData?.targetItems.find(
+  const allItems = [...headerData.targetItems, ...headerData.aboutItems]
+
+  const currentNavigationGroup = allItems.find(
     (x) =>
-      x.megaMenu.primaryListItems.some(
-        (y) => y.URL.toLowerCase() === pathname.toLowerCase()
+      x.megaMenu.primaryListItems.some((y) =>
+        isStringAreEquals(y.URL, pathname)
       ) ||
-      x.megaMenu.secondaryListItems.some(
-        (y) => y.URL.toLowerCase() === pathname.toLowerCase()
+      x.megaMenu.secondaryListItems.some((y) =>
+        isStringAreEquals(y.URL, pathname)
       )
   )
 
@@ -40,11 +43,11 @@ export function Breadcrumb(props: BreadcrumbProps) {
     ...currentNavigationGroup.megaMenu.secondaryListItems,
   ]
 
-  const currentLink = groupLinks.find(
-    (l) => l.URL.toLowerCase() === pathname.toLowerCase()
-  )
+  const currentLink = groupLinks.find((y) => isStringAreEquals(y.URL, pathname))
 
-  const handleOptionChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleOptionChange = (
+    event: React.ChangeEvent<HTMLSelectElement>
+  ): void => {
     let selectedUrl = event.target.value
     selectedUrl = selectedUrl.startsWith('/') ? selectedUrl : '/' + selectedUrl
     router.push(selectedUrl)


### PR DESCRIPTION
 ## Description
Cette pull request permet d'afficher le fil d'arianne sur toutes les pages. 
Celui n'était présent que sur certaine page.

## Changements
Les fichiers concernés par les changements :  
modified:   public_website/src/pages/[...slug].tsx : ajout d'une condition au niveau du render pour afficher Breadcrumb après le header de la page
modified:   public_website/src/ui/components/breadcrumb/Breadcrumb.tsx : prise en compte de la deuxième partie de la navigation (aboutItems) et utilisation de isStringAreEquals.

## Notion
Plusieurs tickets y font référence.
Exemple : [ici](https://www.notion.so/Manque-le-fil-d-ariane-cedfd357ee2947fbb2b56ca9ee06d3f2?pvs=4)