### PR TITLE
fix: fix sur parseText et stripTags

### DIFF
--- a/public_website/src/utils/parseText.tsx
+++ b/public_website/src/utils/parseText.tsx
@@ -6,27 +6,31 @@ export const parseText = (
   processedText: JSX.Element[]
   accessibilityLabel: string
 } => {
-  const textWithLineBreaks = text.replace(/<br\s*\/?>/gi, '\n')
-  const parts = textWithLineBreaks.split(/\*\*/)
-  const accessibilityLabel = parts.join('').replace(/\n/g, '')
+  if (text) {
+    const textWithLineBreaks = text.replace(/<br\s*\/?>/gi, '\n')
+    const parts = textWithLineBreaks.split(/\*\*/)
+    const accessibilityLabel = parts.join('').replace(/\n/g, '')
 
-  const processedText = parts.map((part, index) => {
-    if (index % 2 === 1) {
-      return <mark key={part + index}>{part}</mark>
-    } else {
-      const lines = part.split('\n')
-      return (
-        <span key={part + index}>
-          {lines.map((line, lineIndex) => (
-            <React.Fragment key={line + lineIndex}>
-              {line}
-              {lineIndex < lines.length - 1 && <br />}
-            </React.Fragment>
-          ))}
-        </span>
-      )
-    }
-  })
+    const processedText = parts.map((part, index) => {
+      if (index % 2 === 1) {
+        return <mark key={part + index}>{part}</mark>
+      } else {
+        const lines = part.split('\n')
+        return (
+          <span key={part + index}>
+            {lines.map((line, lineIndex) => (
+              <React.Fragment key={line + lineIndex}>
+                {line}
+                {lineIndex < lines.length - 1 && <br />}
+              </React.Fragment>
+            ))}
+          </span>
+        )
+      }
+    })
 
-  return { processedText, accessibilityLabel }
+    return { processedText, accessibilityLabel }
+  } else {
+    return { processedText: [], accessibilityLabel: '' }
+  }
 }

--- a/public_website/src/utils/stripTags.ts
+++ b/public_website/src/utils/stripTags.ts
@@ -1,9 +1,13 @@
 /**
  * Remove HTML tags from a string and merge spaces
  */
-export function stripTags(string: string): string {
-  return string
-    .replace(/(<([^>]+)>)/gi, '')
-    .replace(/\s\s+/g, ' ')
-    .replace('&nbsp;', ' ')
+export function stripTags(str: string): string {
+  if (str) {
+    return str
+      .replace(/(<([^>]+)>)/gi, '')
+      .replace(/\s\s+/g, ' ')
+      .replace('&nbsp;', ' ')
+  } else {
+    return ''
+  }
 }


### PR DESCRIPTION
## Description

Cette pull request corrige des erreurs générées sur certains pages lorsque des valeurs de champs ne sont pas renseignées mais ne sont pas traitées en condition sur leur existence notamment sur les traitements de chaines de string.
