### PR TITLE
fix: erreur de margin listems page actu

### DIFF
--- a/public_website/src/pages/actualites-pass-culture.tsx
+++ b/public_website/src/pages/actualites-pass-culture.tsx
@@ -213,7 +213,7 @@ const StyledTitle = styled(ContentWrapper)`
 `
 
 const StyledListItems = styled(ListItems)`
-  margin-top: -3rem;
+  margin-top: 0rem;
   --module-spacing: 0;
 
   @media (width < ${(p) => p.theme.mediaQueries.mobile}) {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.javascript.lcov.reportPaths=public_website/coverage/lcov.info
 sonar.coverage.exclusions=**/_*,**/*config.*,**/*setup.*,**/globalstyles.tsx,**/*.test.*,**/*.d.ts,**/__mocks__/**,**/theme/**,**/icons/**,**/*fixtures.*,**/fixtures/**,**/__tests__/handlers.ts,**/__tests__/server.ts,**/__tests__/index.tsx,**/content_management_system/**/*
 
 # Patterns to ignore issues on certain components and for certain coding rules
-sonar.issue.ignore.multicriteria=typescriptS6606,typescriptS6544,typescriptS125,typescriptS3863,typescriptS6759,typescriptS4325,typescript:S6819
+sonar.issue.ignore.multicriteria=typescriptS6606,typescriptS6544,typescriptS125,typescriptS3863,typescriptS6759,typescriptS4325
 
 # Disable this issue "Prefer using nullish coalescing operator (`??`) instead of a logical or (`||`)" because it is not equivalent (source of bugs)
 sonar.issue.ignore.multicriteria.typescriptS6606.ruleKey=typescript:S6606


### PR DESCRIPTION
## Description
Cette PR permet d'ajuster correctement la marge du bloc actu dans la page actualité.