### PR TITLE
fix: ajout props defaultUrl

### DIFF
--- a/content_management_system/src/api/footer/content-types/footer/schema.json
+++ b/content_management_system/src/api/footer/content-types/footer/schema.json
@@ -33,6 +33,10 @@
       "type": "component",
       "repeatable": true,
       "component": "common.link"
+    },
+    "bannerDefaultUrl": {
+      "type": "string",
+      "required": true
     }
   }
 }

--- a/content_management_system/types/generated/contentTypes.d.ts
+++ b/content_management_system/types/generated/contentTypes.d.ts
@@ -810,6 +810,7 @@ export interface ApiFooterFooter extends Schema.SingleType {
     Lists: Attribute.Component<'footer.list', true>;
     bannerText: Attribute.String;
     LegalLinks: Attribute.Component<'common.link', true>;
+    bannerDefaultUrl: Attribute.String & Attribute.Required;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;

--- a/public_website/src/types/contentTypes.d.ts
+++ b/public_website/src/types/contentTypes.d.ts
@@ -810,6 +810,7 @@ export interface ApiFooterFooter extends Schema.SingleType {
     Lists: Attribute.Component<'footer.list', true>;
     bannerText: Attribute.String;
     LegalLinks: Attribute.Component<'common.link', true>;
+    bannerDefaultUrl: Attribute.String & Attribute.Required;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;

--- a/public_website/src/types/props.ts
+++ b/public_website/src/types/props.ts
@@ -436,7 +436,7 @@ export type LogoProps = {
 export type AppBannerProps = {
   title?: string
   androidUrl?: string
-  defaultUrl?: string
+  defaultUrl: string
   iosUrl?: string
   onClick?: () => void
 }
@@ -444,6 +444,7 @@ export type FooterProps = {
   PlayStoreUrl: string
   AppStoreUrl: string
   bannerText: string
+  bannerDefaultUrl: string
   LegalLinks: { Label: string; URL: string; id: number }[]
   Lists: {
     id: number

--- a/public_website/src/ui/components/footer/Footer.tsx
+++ b/public_website/src/ui/components/footer/Footer.tsx
@@ -11,7 +11,15 @@ import { FooterProps } from '@/types/props'
 import { Link } from '@/ui/components/Link'
 
 export function Footer(props: FooterProps) {
-  const { PlayStoreUrl, AppStoreUrl, bannerText, LegalLinks, Lists } = props
+  const {
+    PlayStoreUrl,
+    AppStoreUrl,
+    bannerText,
+    LegalLinks,
+    Lists,
+    bannerDefaultUrl = '',
+  } = props
+
   return (
     <StyledFooter id="footer">
       <StyledContentContainer>
@@ -27,6 +35,7 @@ export function Footer(props: FooterProps) {
               title={bannerText}
               androidUrl={AppStoreUrl}
               iosUrl={PlayStoreUrl}
+              defaultUrl={bannerDefaultUrl}
               onClick={(): void =>
                 onClickAnalytics({
                   eventName: 'downloadApp',

--- a/public_website/src/ui/components/header/HeaderBanner.tsx
+++ b/public_website/src/ui/components/header/HeaderBanner.tsx
@@ -7,7 +7,12 @@ import { BannerProps } from '@/types/props'
 import { isRenderable } from '@/utils/isRenderable'
 
 const HeaderBanner = (props: BannerProps) => {
-  const { bannerText, bannerAndroidUrl, bannerDefaultUrl, bannerIosUrl } = props
+  const {
+    bannerText,
+    bannerAndroidUrl,
+    bannerDefaultUrl = '',
+    bannerIosUrl,
+  } = props
 
   const isRenderBanner = (): boolean => {
     return (


### PR DESCRIPTION
## Description
Cette PR permet de fixer l'affichage de la banner pour télécharger l'app disponible sur les stores.
3 urls sont à renseigner : 1  pour le store apple, 1 pour les store google et une url par défaut.
La redirection s'effectue selon le device.
