### PR TITLE
fix: pas de menu dots en desktop

### DIFF
--- a/public_website/src/lib/blocks/experienceVideoCarousel/experienceVideoCarousel.tsx
+++ b/public_website/src/lib/blocks/experienceVideoCarousel/experienceVideoCarousel.tsx
@@ -95,7 +95,8 @@ export function ExperienceVideoCarousel(props: ExperienceVideoCarouselProps) {
             </StyledSlider>
           </BlockRendererWithCondition>
 
-          <BlockRendererWithCondition condition={isNavShowing}>
+          <BlockRendererWithCondition
+            condition={isNavShowing && width < MOBILE_WIDTH}>
             <NavigationWithDots
               items={items}
               carrouselSelector={EXPERIENCE_VIDEO_CAROUSEL_SELECTOR}


### PR DESCRIPTION
## Description
Cette PR corrige le menu dots (experienceVideoCarousel) qui restait actif en desktop. il manquait une condition sur son affichage.