### PR TITLE
fix: fil arianne mal placé

### DIFF
--- a/public_website/src/pages/_document.tsx
+++ b/public_website/src/pages/_document.tsx
@@ -32,7 +32,7 @@ export default class MyDocument extends Document {
 
   render() {
     return (
-      <Html lang="en">
+      <Html lang="fr">
         <Head>
           <link rel="manifest" href="/site.webmanifest" />
           <link

--- a/public_website/src/pages/actualite/[slug].tsx
+++ b/public_website/src/pages/actualite/[slug].tsx
@@ -21,10 +21,11 @@ export default function CustomPage(props: CustomPageProps) {
     <React.Fragment>
       <Seo metaData={seo} />
       <Header image={image} icon="" title={title} aboveTitle={aboveTitle} />
+      <Breadcrumb isUnderHeader />
       {blocks?.map((block) => (
         <BlockRenderer key={`${block.__component}_${block.id}`} block={block} />
       ))}
-      <Breadcrumb isUnderHeader />
+
       <StyledLatestNews
         news={props.latestStudies}
         title="Les dernières **actualités**"


### PR DESCRIPTION
## Description
Cette PR règle le problème de placement du fil d'ariane sur les pages des articles.
J'en ai profité pour modifier l'attribut lang qui était par défaut en.