### PR TITLE
fix: ariane simulateur et isolation requetes

### DIFF
--- a/public_website/__tests__/hooks/useLockBodyScroll.test.tsx
+++ b/public_website/__tests__/hooks/useLockBodyScroll.test.tsx
@@ -16,8 +16,7 @@ describe('useLockBodyScroll', () => {
   })
 
   it('restores original body scroll when not active', () => {
-    const originalOverflow = document.body.style.overflow
     render(<TestComponent isLock={false} />)
-    expect(document.body.style.overflow).toBe(originalOverflow)
+    expect(document.body.style.overflow).toBe('')
   })
 })

--- a/public_website/__tests__/hooks/useLockBodyScroll.test.tsx
+++ b/public_website/__tests__/hooks/useLockBodyScroll.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { render } from '../index'
+import useLockBodyScroll from '@/hooks/useLockBodyScroll'
+
+function TestComponent({ isLock }: { isLock: boolean }) {
+  useLockBodyScroll(isLock)
+  return <div>Content</div>
+}
+
+describe('useLockBodyScroll', () => {
+  it('locks body scroll when active', () => {
+    render(<TestComponent isLock />)
+    expect(document.body.style.overflow).toBe('hidden')
+  })
+
+  it('restores original body scroll when not active', () => {
+    const originalOverflow = document.body.style.overflow
+    render(<TestComponent isLock={false} />)
+    expect(document.body.style.overflow).toBe(originalOverflow)
+  })
+})

--- a/public_website/src/domain/events/events.actions.ts
+++ b/public_website/src/domain/events/events.actions.ts
@@ -1,0 +1,12 @@
+import { APIResponseData } from '@/types/strapi'
+import { fetchCMS } from '@/utils/fetchCMS'
+
+export const getEvents = async (
+  queryParams: string
+): Promise<APIResponseData<'api::event.event'>[]> => {
+  const apiEndpoint = `/events?${queryParams}`
+  const response =
+    await fetchCMS<APIResponseData<'api::event.event'>[]>(apiEndpoint)
+  const { data } = response
+  return data
+}

--- a/public_website/src/domain/events/events.output.ts
+++ b/public_website/src/domain/events/events.output.ts
@@ -1,0 +1,5 @@
+import { getEvents as getEventsService } from './events.actions'
+
+export const Events = {
+  getEvents: (queryParams: string) => getEventsService(queryParams),
+}

--- a/public_website/src/domain/news/news.actions.ts
+++ b/public_website/src/domain/news/news.actions.ts
@@ -1,0 +1,12 @@
+import { APIResponseData } from '@/types/strapi'
+import { fetchCMS } from '@/utils/fetchCMS'
+
+export const getNews = async (
+  queryParams: string
+): Promise<APIResponseData<'api::news.news'>[]> => {
+  const apiEndpoint = `/news-list?${queryParams}`
+  const response =
+    await fetchCMS<APIResponseData<'api::news.news'>[]>(apiEndpoint)
+  const { data } = response
+  return data
+}

--- a/public_website/src/domain/news/news.output.ts
+++ b/public_website/src/domain/news/news.output.ts
@@ -1,0 +1,5 @@
+import { getNews as getNewsService } from './news.actions'
+
+export const News = {
+  getNews: (queryParams: string) => getNewsService(queryParams),
+}

--- a/public_website/src/domain/resources/resources.actions.ts
+++ b/public_website/src/domain/resources/resources.actions.ts
@@ -1,0 +1,12 @@
+import { APIResponseData } from '@/types/strapi'
+import { fetchCMS } from '@/utils/fetchCMS'
+
+export const getResources = async (
+  queryParams: string
+): Promise<APIResponseData<'api::resource.resource'>[]> => {
+  const apiEndpoint = `/resources?${queryParams}`
+  const response =
+    await fetchCMS<APIResponseData<'api::resource.resource'>[]>(apiEndpoint)
+  const { data } = response
+  return data
+}

--- a/public_website/src/domain/resources/resources.output.ts
+++ b/public_website/src/domain/resources/resources.output.ts
@@ -1,0 +1,5 @@
+import { getResources as getResourcesService } from './resources.actions'
+
+export const Resources = {
+  getResources: (queryParams: string) => getResourcesService(queryParams),
+}

--- a/public_website/src/hooks/useLockBodyScroll.ts
+++ b/public_website/src/hooks/useLockBodyScroll.ts
@@ -5,16 +5,12 @@ function useLockBodyScroll(lock: boolean = true) {
     if (typeof document === 'undefined') {
       return
     }
+    const setOverFlowBody = () =>
+      (document.body.style.overflow = lock ? 'hidden' : '')
 
-    const originalStyle = window.getComputedStyle(document.body).overflow
-    if (lock) {
-      document.body.style.overflow = 'hidden'
-    }
-
+    setOverFlowBody()
     return () => {
-      if (lock) {
-        document.body.style.overflow = originalStyle
-      }
+      setOverFlowBody()
     }
   }, [lock])
 }

--- a/public_website/src/hooks/useLockBodyScroll.ts
+++ b/public_website/src/hooks/useLockBodyScroll.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react'
+
+function useLockBodyScroll(lock: boolean = true) {
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return
+    }
+
+    const originalStyle = window.getComputedStyle(document.body).overflow
+    if (lock) {
+      document.body.style.overflow = 'hidden'
+    }
+
+    return () => {
+      if (lock) {
+        document.body.style.overflow = originalStyle
+      }
+    }
+  }, [lock])
+}
+
+export default useLockBodyScroll

--- a/public_website/src/lib/blocks/Faq.tsx
+++ b/public_website/src/lib/blocks/Faq.tsx
@@ -62,9 +62,9 @@ export function Faq(props: FaqProps) {
 
   return (
     <ContentWrapper>
-      <StyledHeading>{title}</StyledHeading>
       <StyledContentWrapper>
         <StyledContentTextWrapper>
+          <StyledHeading>{title}</StyledHeading>
           <ButtonWithCTA cta={cta} />
         </StyledContentTextWrapper>
         <div>

--- a/public_website/src/lib/blocks/verticalCarousel/VerticalCarousel.tsx
+++ b/public_website/src/lib/blocks/verticalCarousel/VerticalCarousel.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useMemo } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { CarouselProvider, Slider } from 'pure-react-carousel'
 import styled, { css } from 'styled-components'
 
 import NavigationWithArrow from '../../../ui/components/nav-carousel/NavigationWithArrow'
 import NavigationWithDots from '../../../ui/components/nav-carousel/NavigationWithDots'
 import { VerticalCarouselSlide } from './VerticalCarouselSlide'
+import useLockBodyScroll from '@/hooks/useLockBodyScroll'
 import { useWindowSize } from '@/hooks/useWindowSize'
 import BlockRendererWithCondition from '@/lib/BlockRendererWithCondition'
 import { MediaQueries } from '@/theme/media-queries'
@@ -20,6 +21,10 @@ const LARGE_DESKTOP_WIDTH = getMediaQuery(MediaQueries.LARGE_DESKTOP)
 
 export function VerticalCarousel(props: VerticalCarouselProps) {
   const { title, items, hidePlayIcon } = props
+
+  const [isScroll, setIsSctoll] = useState<boolean>(false)
+  useLockBodyScroll(isScroll)
+
   const itemsFilter = items.filter((item) => {
     return item.image && item.image !== ''
   })
@@ -70,6 +75,7 @@ export function VerticalCarousel(props: VerticalCarouselProps) {
           isIntrinsicHeight
           infinite={false}
           dragEnabled
+          touchEnabled
           step={1}>
           <BlockRendererWithCondition condition={isNavShowing}>
             <StyledHeading>
@@ -84,6 +90,8 @@ export function VerticalCarousel(props: VerticalCarouselProps) {
           </BlockRendererWithCondition>
 
           <StyledSlider
+            onTouchStart={(): void => setIsSctoll(true)}
+            onTouchEnd={(): void => setIsSctoll(false)}
             classNameAnimation="customCarrouselAnimation"
             role="region"
             aria-label={stripTags(title)}

--- a/public_website/src/lib/blocks/verticalCarousel/VerticalCarousel.tsx
+++ b/public_website/src/lib/blocks/verticalCarousel/VerticalCarousel.tsx
@@ -22,8 +22,8 @@ const LARGE_DESKTOP_WIDTH = getMediaQuery(MediaQueries.LARGE_DESKTOP)
 export function VerticalCarousel(props: VerticalCarouselProps) {
   const { title, items, hidePlayIcon } = props
 
-  const [isScroll, setIsSctoll] = useState<boolean>(false)
-  useLockBodyScroll(isScroll)
+  const [hasScroll, setHasScroll] = useState<boolean>(false)
+  useLockBodyScroll(hasScroll)
 
   const itemsFilter = items.filter((item) => {
     return item.image && item.image !== ''
@@ -90,8 +90,8 @@ export function VerticalCarousel(props: VerticalCarouselProps) {
           </BlockRendererWithCondition>
 
           <StyledSlider
-            onTouchStart={(): void => setIsSctoll(true)}
-            onTouchEnd={(): void => setIsSctoll(false)}
+            onTouchStart={(): void => setHasScroll(true)}
+            onTouchEnd={(): void => setHasScroll(false)}
             classNameAnimation="customCarrouselAnimation"
             role="region"
             aria-label={stripTags(title)}

--- a/public_website/src/pages/actualite/[slug].tsx
+++ b/public_website/src/pages/actualite/[slug].tsx
@@ -3,6 +3,7 @@ import type { GetStaticPaths, GetStaticProps } from 'next'
 import { stringify } from 'qs'
 import styled, { css } from 'styled-components'
 
+import { News } from '@/domain/news/news.output'
 import { BlockRenderer } from '@/lib/BlockRenderer'
 import { Header } from '@/lib/blocks/Header'
 import { LatestNews } from '@/lib/blocks/LatestNews'
@@ -10,6 +11,7 @@ import { Seo } from '@/lib/seo/seo'
 import { APIResponseData } from '@/types/strapi'
 import { Breadcrumb } from '@/ui/components/breadcrumb/Breadcrumb'
 import { fetchCMS } from '@/utils/fetchCMS'
+
 interface CustomPageProps {
   data: APIResponseData<'api::news.news'>
   latestStudies: APIResponseData<'api::news.news'>[]
@@ -74,16 +76,12 @@ export const getStaticProps = (async ({ params }) => {
     }
   )
 
-  const apiEndpoint = `/news-list?${queryParams}`
+  const actu = await News.getNews(queryParams)
 
-  const response =
-    await fetchCMS<APIResponseData<'api::news.news'>[]>(apiEndpoint)
-
-  if (response.data.length === 0) {
+  if (actu.length === 0) {
     return { notFound: true }
   }
-
-  const latestStudiesQuery = stringify({
+  const latestActuQuery = stringify({
     sort: ['date:desc'],
     populate: ['image'],
     pagination: {
@@ -91,21 +89,19 @@ export const getStaticProps = (async ({ params }) => {
     },
     filters: {
       category: {
-        $eqi: response.data[0]!.attributes.category,
+        $eqi: actu[0]!.attributes.category,
       },
       title: {
-        $ne: response.data[0]!.attributes.title,
+        $ne: actu[0]!.attributes.title,
       },
     },
   })
-  const latestStudies = await fetchCMS<APIResponseData<'api::news.news'>[]>(
-    `/news-list?${latestStudiesQuery}`
-  )
+  const latestActu = await News.getNews(latestActuQuery)
 
   return {
     props: {
-      data: response.data[0]!,
-      latestStudies: latestStudies.data,
+      data: actu[0]!,
+      latestStudies: latestActu,
     },
   }
 }) satisfies GetStaticProps<CustomPageProps>

--- a/public_website/src/pages/ressources/[slug].tsx
+++ b/public_website/src/pages/ressources/[slug].tsx
@@ -3,6 +3,7 @@ import type { GetStaticPaths, GetStaticProps } from 'next'
 import { stringify } from 'qs'
 import styled, { css } from 'styled-components'
 
+import { Resources } from '@/domain/resources/resources.output'
 import { BlockRenderer } from '@/lib/BlockRenderer'
 import { Header } from '@/lib/blocks/Header'
 import { LatestNews } from '@/lib/blocks/LatestNews'
@@ -88,12 +89,9 @@ export const getStaticProps = (async ({ params }) => {
     }
   )
 
-  const apiEndpoint = `/resources?${queryParams}`
+  const response = await Resources.getResources(queryParams)
 
-  const response =
-    await fetchCMS<APIResponseData<'api::resource.resource'>[]>(apiEndpoint)
-
-  if (response.data.length === 0) {
+  if (response.length === 0) {
     return { notFound: true }
   }
 
@@ -105,21 +103,20 @@ export const getStaticProps = (async ({ params }) => {
     },
     filters: {
       title: {
-        $ne: response.data[0]!.attributes.title,
+        $ne: response[0]!.attributes.title,
       },
       category: {
-        $eqi: response.data[0]!.attributes.category,
+        $eqi: response[0]!.attributes.category,
       },
     },
   })
-  const latestStudies = await fetchCMS<
-    APIResponseData<'api::resource.resource'>[]
-  >(`/resources?${latestStudiesQuery}`)
+
+  const latestResources = await Resources.getResources(latestStudiesQuery)
 
   return {
     props: {
-      data: response.data[0]!,
-      latestStudies: latestStudies.data,
+      data: response[0]!,
+      latestStudies: latestResources,
     },
   }
 }) satisfies GetStaticProps<CustomPageProps>

--- a/public_website/src/ui/components/header/MegaMenu.tsx
+++ b/public_website/src/ui/components/header/MegaMenu.tsx
@@ -8,6 +8,7 @@ import HeaderBanner from './HeaderBanner'
 import { MegaMenuProps } from '@/types/props'
 import { Link } from '@/ui/components/Link'
 import { parseText } from '@/utils/parseText'
+import { isStringAreEquals } from '@/utils/stringAreEquals'
 
 export function MegaMenu({
   onBlur,
@@ -69,6 +70,14 @@ export function MegaMenu({
     }
   })
 
+  const primaryListItemsWithoutSimulator = React.useMemo(
+    () =>
+      primaryListItems.filter(
+        (item) => !isStringAreEquals(item.Label, 'simulateur')
+      ),
+    [primaryListItems]
+  )
+
   return (
     <StyledMegaMenuWrapper onMouseLeave={onMouseLeave}>
       <StyledMegaMenu ref={megaMenuRef} id={id} aria-labelledby={labelId}>
@@ -85,7 +94,7 @@ export function MegaMenu({
 
         <StyledMegaMenuLists>
           <ul>
-            {primaryListItems?.map((item) => {
+            {primaryListItemsWithoutSimulator?.map((item) => {
               return (
                 <li key={item.Label}>
                   <Link

--- a/public_website/src/ui/globalstyles.tsx
+++ b/public_website/src/ui/globalstyles.tsx
@@ -191,7 +191,8 @@ const GlobalStyles = createGlobalStyle`
 
  
   body {
-
+    -webkit-text-size-adjust: 100%;
+    -webkit-tap-highlight-color: transparent;
     --module-margin: 5rem;
     --module-spacing: calc(var(--module-margin) * 2);
 


### PR DESCRIPTION
## Description
Cette PR permet d'ajouter le fil d'ariane dans le simulateur (celui ne faisant pas partie des items du megamenu, le fil d'ariane était incomplet).
D'autre part, je propose d'isoler les services requêtes (à valider). 
Enfin j'en ai profité pour faire un test sur un carousel pour améliorer l'expérience user en désactivant le scroll vertical si on scrolle le carousel (= à généraliser si concluant).