### PR TITLE
fix: simulator support link

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -357,7 +357,7 @@ Exhibit A - Source Code Form License Notice
 
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 If it is not possible or desirable to put the notice in a particular
 file, then You may include the notice in a location (such as a LICENSE

--- a/public_website/src/ui/components/simulator/ResultScreen.tsx
+++ b/public_website/src/ui/components/simulator/ResultScreen.tsx
@@ -35,7 +35,7 @@ export function ResultScreen(props: ResultScreenProps) {
         <span aria-label={parseText(props.helpText).accessibilityLabel}>
           {parseText(props.helpText).processedText}
         </span>
-        <Link href={props.ctaLink.URL}>{props.supportLink.Label}</Link>
+        <Link href={props.supportLink.URL}>{props.supportLink.Label}</Link>
       </HelpText>
     </Root>
   )


### PR DESCRIPTION
## Description
Le Lien qui se trouve sur la vue résultat dans le simulateur ne renvoie pas sur le compte mailto défini dans le back office.

## Analyse
La props passée à Link était ctaLink.URL ou lieu de supportLink.URL

## Correction
La props a donc été corrigée (fichier concerné ResultScreen.tsx) afin de pouvoir remonter correctement le mailto renseigné sur Srapi. (mailto:support@passculture.app)