### PR TITLE
fix: add footer links breadcrumb

### DIFF
--- a/content_management_system/types/generated/components.d.ts
+++ b/content_management_system/types/generated/components.d.ts
@@ -214,26 +214,6 @@ export interface HomeEligibilityItems extends Schema.Component {
   };
 }
 
-export interface FooterList extends Schema.Component {
-  collectionName: 'components_footer_lists';
-  info: {
-    displayName: 'Lists';
-    description: '';
-  };
-  attributes: {
-    Title: Attribute.String & Attribute.Required;
-    Links: Attribute.Component<'common.link', true>;
-  };
-}
-
-export interface FooterLegalLinks extends Schema.Component {
-  collectionName: 'components_footer_legal_links';
-  info: {
-    displayName: 'LegalLinks';
-  };
-  attributes: {};
-}
-
 export interface HeaderNavigationItems extends Schema.Component {
   collectionName: 'components_header_navigation_items';
   info: {
@@ -407,6 +387,26 @@ export interface HeaderAccountDropdown extends Schema.Component {
     items: Attribute.Component<'header.account-item', true> &
       Attribute.Required;
   };
+}
+
+export interface FooterList extends Schema.Component {
+  collectionName: 'components_footer_lists';
+  info: {
+    displayName: 'Lists';
+    description: '';
+  };
+  attributes: {
+    Title: Attribute.String & Attribute.Required;
+    Links: Attribute.Component<'common.link', true>;
+  };
+}
+
+export interface FooterLegalLinks extends Schema.Component {
+  collectionName: 'components_footer_legal_links';
+  info: {
+    displayName: 'LegalLinks';
+  };
+  attributes: {};
 }
 
 export interface CommonVerticalCarouselItem extends Schema.Component {
@@ -1252,8 +1252,6 @@ declare module '@strapi/types' {
       'home.hero-section': HomeHeroSection;
       'home.eligibility-section': HomeEligibilitySection;
       'home.eligibility-items': HomeEligibilityItems;
-      'footer.list': FooterList;
-      'footer.legal-links': FooterLegalLinks;
       'header.navigation-items': HeaderNavigationItems;
       'header.mega-menu': HeaderMegaMenu;
       'header.login': HeaderLogin;
@@ -1261,6 +1259,8 @@ declare module '@strapi/types' {
       'header.header': HeaderHeader;
       'header.account-item': HeaderAccountItem;
       'header.account-dropdown': HeaderAccountDropdown;
+      'footer.list': FooterList;
+      'footer.legal-links': FooterLegalLinks;
       'common.vertical-carousel-item': CommonVerticalCarouselItem;
       'common.simple-text-column': CommonSimpleTextColumn;
       'common.piled-card-item': CommonPiledCardItem;

--- a/public_website/src/pages/_app.tsx
+++ b/public_website/src/pages/_app.tsx
@@ -48,8 +48,9 @@ export default function MyApp({
     () => ({
       targetItems: headerData.targetItems,
       aboutItems: headerData.aboutItems,
+      footerItems: footerData.LegalLinks,
     }),
-    [headerData.targetItems, headerData.aboutItems]
+    [headerData.targetItems, headerData.aboutItems, footerData.LegalLinks]
   )
 
   return (

--- a/public_website/src/types/props.ts
+++ b/public_website/src/types/props.ts
@@ -93,6 +93,11 @@ export type ImageTextProps = {
   icon?: string
   isImageRight?: boolean
 }
+export type BreadcrumbDataProps = {
+  targetItems: HeaderNavigationItemProps[]
+  aboutItems: HeaderNavigationItemProps[]
+  footerItems: { Label: string; URL: string; id: number }[]
+}
 export type HeaderMenuProps = {
   targetItems: HeaderNavigationItemProps[]
   aboutItems: HeaderNavigationItemProps[]

--- a/public_website/src/ui/components/breadcrumb/Breadcrumb.tsx
+++ b/public_website/src/ui/components/breadcrumb/Breadcrumb.tsx
@@ -22,13 +22,13 @@ export function Breadcrumb(props: BreadcrumbProps) {
   const params = useParams()
   const { onClickAnalytics } = useOnClickAnalytics()
 
-  const headerData = useContext(BreadcrumbContext)
+  const breadcrumbData = useContext(BreadcrumbContext)
   const pathname = usePathname()
 
-  const allItems = headerData
-    ? [...headerData.targetItems, ...headerData.aboutItems]
+  const allItems = breadcrumbData
+    ? [...breadcrumbData.targetItems, ...breadcrumbData.aboutItems]
     : []
-
+  const footerItems = breadcrumbData ? [...breadcrumbData.footerItems] : []
   const currentNavigationGroup = allItems.find(
     (x) =>
       x.megaMenu.primaryListItems.some((y: { URL: string }) =>
@@ -69,6 +69,20 @@ export function Breadcrumb(props: BreadcrumbProps) {
       pathname.startsWith('/ressources/')
     )
   }
+  const isFooterLink = (): boolean => {
+    return footerItems.some((obj) => isStringAreEquals(obj.URL, pathname))
+  }
+  const getFooterItem = (): {
+    Label: string
+    URL: string
+    id: number
+  } | null => {
+    const item = footerItems.find((obj) => isStringAreEquals(obj.URL, pathname))
+
+    if (item) return item
+    return null
+  }
+  const footerLink = getFooterItem()
 
   const memoizeUL = useMemo(() => {
     return (
@@ -102,7 +116,6 @@ export function Breadcrumb(props: BreadcrumbProps) {
 
   const label = currentNavigationGroup?.label
 
-  //Faudrait récupérer /actualites-pass-culture de manière dynamique
   useEffect(() => {
     setIsMounted(true)
   }, [])
@@ -132,6 +145,11 @@ export function Breadcrumb(props: BreadcrumbProps) {
           {isResource() && (
             <StyledSimpleLink>
               <Link href="/ressources-pass-culture">Ressources</Link>
+            </StyledSimpleLink>
+          )}
+          {isFooterLink() && footerLink && (
+            <StyledSimpleLink>
+              <Link href={footerLink.URL}>{footerLink.Label}</Link>
             </StyledSimpleLink>
           )}
           <ListItem>

--- a/public_website/src/ui/components/breadcrumb/Breadcrumb.tsx
+++ b/public_website/src/ui/components/breadcrumb/Breadcrumb.tsx
@@ -69,9 +69,7 @@ export function Breadcrumb(props: BreadcrumbProps) {
       pathname.startsWith('/ressources/')
     )
   }
-  const isFooterLink = (): boolean => {
-    return footerItems.some((obj) => isStringAreEquals(obj.URL, pathname))
-  }
+
   const getFooterItem = (): {
     Label: string
     URL: string
@@ -147,7 +145,7 @@ export function Breadcrumb(props: BreadcrumbProps) {
               <Link href="/ressources-pass-culture">Ressources</Link>
             </StyledSimpleLink>
           )}
-          {isFooterLink() && footerLink && (
+          {footerLink && (
             <StyledSimpleLink>
               <Link href={footerLink.URL}>{footerLink.Label}</Link>
             </StyledSimpleLink>

--- a/public_website/src/ui/components/breadcrumb/breadcrumb-context.ts
+++ b/public_website/src/ui/components/breadcrumb/breadcrumb-context.ts
@@ -1,8 +1,8 @@
 import { createContext } from 'react'
 
-import { HeaderMenuProps } from '@/types/props'
+import { BreadcrumbDataProps } from '@/types/props'
 
-type BreadcrumbContextData = Pick<HeaderMenuProps, 'aboutItems' | 'targetItems'>
+type BreadcrumbContextData = BreadcrumbDataProps
 
 export const BreadcrumbContext = createContext<BreadcrumbContextData | null>(
   null


### PR DESCRIPTION
## Description
Certains liens présents dans la partie basse du footer n'était pas pris en compte dans le fil d'ariane.
Effectivement, dans le contexte du fil d'ariane, n'était pris en compte que les items du menu principale qui se retrouve en partie dans le footer également)

## Correction
J'ai donc ajouté la partie du footer non pris en compte dans le fil d'ariane dans le contexte (BreadcrumbContext) du fil d'arianne.
J'ai ajouté une props pour plus de cohérence BreadcrumbDataProps et modifié le traintement coté Breadcrumb.tsx.