### PR TITLE
feat(proxy): add testing proxy setup for strapi testing environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,46 @@
 # pass Culture Institutional
 
-Welcome to the pass culture institutional project !
-
-This repo contains two important folders `public_website` (Next) and `content_management_system` (Strapi) for the institutional site.
-
-This README contains general information that concerns the both folders.
-
-For more specific information:
-
-[Public website documentation](./public_website/README.md)
-
-[Content management system documentation](./content_management_system/README.md)
-
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=pass-culture_pass-culture-institutional&metric=code_smells)](https://sonarcloud.io/summary/overall?id=pass-culture_pass-culture-institutional)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=pass-culture_pass-culture-institutional&metric=coverage)](https://sonarcloud.io/summary/overall?id=pass-culture_pass-culture-institutional)
 [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=pass-culture_pass-culture-institutional&metric=duplicated_lines_density)](https://sonarcloud.io/summary/overall?id=pass-culture_pass-culture-institutional)
+
+Welcome to the **pass Culture Institutional** project!
+
+This repository contains the following key components for the institutional site:
+
+- **`public_website`**: The frontend application built with **Next.js**.
+- **`content_management_system`**: The backend powered by **Strapi**.
+
+In addition, the project provides tools to streamline local development and testing by connecting to the **Strapi testing backend** behind Google Cloud IAP.
+
+This README provides general project information, scripts, and setup instructions. For detailed documentation on each part of the project:
+
+- [Public Website Documentation](./public_website/README.md)
+- [Content Management System Documentation](./content_management_system/README.md)
+- [Strapi Testing Proxy Documentation](./nginx-strapi-testing-proxy/README.md)
+
+---
+
+## Table of Contents
+
+- [pass Culture Institutional](#pass-culture-institutional)
+  - [Table of Contents](#table-of-contents)
+  - [Requirements](#requirements)
+  - [Start the project](#start-the-project)
+  - [Local Database](#local-database)
+  - [Access the Strapi Testing Backend](#access-the-strapi-testing-backend)
+    - [Key Features:](#key-features)
+    - [Quick Start:](#quick-start)
+  - [Project Scripts](#project-scripts)
+  - [Testing](#testing)
+    - [Public website](#public-website)
+    - [Content management system](#content-management-system)
+      - [Sharing types between the front \& back](#sharing-types-between-the-front--back)
+      - [Why aren't there any unit test on the CMS?](#why-arent-there-any-unit-test-on-the-cms)
+  - [PR title format 🤖](#pr-title-format-)
+    - [Why](#why)
+      - [About squashing the PR commits](#about-squashing-the-pr-commits)
+    - [Key points](#key-points)
 
 ## Requirements
 
@@ -40,23 +66,51 @@ If you want to run the content_management_system locally, you need to install Po
 
 More information on how to setup here: [content_management_system documentation](./content_management_system/README.md)
 
+## Access the Strapi Testing Backend
+
+To connect your local frontend to the Strapi testing backend (secured behind Google Cloud IAP) and transfer data to your local database, refer to the detailed documentation in the [Strapi Testing Proxy](./nginx-strapi-testing-proxy/README.md).
+
+### Key Features:
+
+1. **Proxy Setup**: Allows your local frontend to communicate with the Strapi testing server.
+2. **Data Transfer**: Synchronize the testing environment data into your local database for seamless development and debugging.
+
+### Quick Start:
+
+1. Follow the setup instructions in the [Strapi Testing Proxy README](./nginx-strapi-testing-proxy/README.md).
+2. Use the available scripts:
+   - `yarn proxy:testing`: Start the proxy server.
+   - `yarn proxy:transfer`: Transfer data from the Strapi testing backend to your local database.
+3. Point your frontend (`public_website`) to the local proxy:
+   ```env
+   NEXT_PUBLIC_STRAPI_API_URL=http://localhost:8080
+   ```
+
+For detailed steps and troubleshooting, see the full [Strapi Testing Proxy documentation](./nginx-strapi-testing-proxy/README.md).
+
 ## Project Scripts
 
 Before you can use the scripts, ensure you have `Yarn` installed on your system.
-The project includes several scripts to simplify development and setup:
+The project includes several useful scripts for development, testing, and proxy setup
 
-- `yarn public_website`: Start the public_website development server.
-- `yarn content_management_system`: Start the content_management_system development server.
-- `yarn clear`: Remove temporary files and caches in the public_website directory.
-- `yarn setup:public_website`: Install the public_website dependencies.
-- `yarn setup:content_management_system`: Install the content_management_system dependencies.
-- `yarn setup`: Install the public_website and content_management_system project dependencies.
-- `yarn dev`: Run during development. It clears caches, and starts the public_website and content_management_system servers.
-- `yarn audit:all`: Test all the vulnerabilities packages.
-- `yarn test:deadcode`: Test both public_website and content_management_system dead code.
-- `yarn test:deadcode:update`: Update the public_website and content_management_system dead code snapshots.
-- `yarn test:lint`: Test both public_website and content_management_system linting.
-- `yarn test:types`: Test both public_website and content_management_system typing.
+| **Command**                            | **Description**                                                                 |
+| -------------------------------------- | ------------------------------------------------------------------------------- |
+| `yarn setup`                           | Install dependencies for both `public_website` and `content_management_system`. |
+| `yarn dev`                             | Start both the frontend and backend servers for development.                    |
+| `yarn public_website`                  | Start the `public_website` development server.                                  |
+| `yarn content_management_system`       | Start the `content_management_system` development server.                       |
+| `yarn clear`                           | Remove temporary files and caches in the `public_website` directory.            |
+| `yarn setup:public_website`            | Install dependencies for the `public_website` only.                             |
+| `yarn setup:content_management_system` | Install dependencies for the `content_management_system` only.                  |
+| `yarn audit:all`                       | Check for vulnerabilities in project dependencies.                              |
+| `yarn test:deadcode`                   | Detect unused (dead) code in both projects.                                     |
+| `yarn test:deadcode:update`            | Update snapshots for dead code detection.                                       |
+| `yarn test:lint`                       | Run linting for both frontend and backend.                                      |
+| `yarn test:types`                      | Verify TypeScript types across the project.                                     |
+| `yarn proxy:testing`                   | Start the testing proxy server to connect to the Strapi testing backend.        |
+| `yarn proxy:testing:infinite`          | Run the proxy server in infinite mode with automatic JWT regeneration.          |
+| `yarn proxy:testing:stop`              | Stop the currently running proxy server.                                        |
+| `yarn proxy:transfer`                  | Transfer data from the Strapi testing backend to your local database.           |
 
 ## Testing
 
@@ -101,6 +155,7 @@ The commits of the PR won't be on `main`, but are still useful for PR readiness 
 Here is a recap:
 
 ```
+
 <type>[optional scope]: <description>
   │          │               │
   │          │               └─⫸ PR Description: A short and concise summary of the changes. Present tense.
@@ -110,6 +165,7 @@ Here is a recap:
   |
   │
   └─⫸ PR Type: build:, chore:, ci:, docs:, feat:, fix:, perf:, refactor:, revert:, style:, test:
+
 ```
 
 Here is a more detailed explanation for different types:

--- a/nginx-strapi-testing-proxy/Dockerfile
+++ b/nginx-strapi-testing-proxy/Dockerfile
@@ -1,0 +1,12 @@
+FROM nginx:1.27.3
+
+RUN apt-get update && \
+    apt-get install -y gettext-base && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+COPY nginx.conf /etc/nginx/nginx.conf.template
+
+CMD ["sh", "-c", "envsubst '$IAP_ID_TOKEN' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && exec nginx -g 'daemon off;'"]
+
+
+EXPOSE 8080

--- a/nginx-strapi-testing-proxy/README.md
+++ b/nginx-strapi-testing-proxy/README.md
@@ -1,0 +1,189 @@
+# Strapi Testing Proxy
+
+This repository provides tools to facilitate local development by accessing the **Strapi testing backend**, which is secured behind Google Cloud IAP (Identity-Aware Proxy).
+
+The purpose of this repository is twofold:
+
+1. **Proxy Access**: Use the provided tools to set up a proxy that allows your local frontend (e.g., `public_website`) to connect to the Strapi testing server available at [this address](https://siteinstit-cms.testing.passculture.team/).
+2. **Data Transfer**: Synchronize data from the testing backend to your local database for development and testing purposes.
+
+This setup ensures seamless access to the testing backend for development and allows you to replicate real data locally for debugging and validation.
+
+---
+
+## Table of Contents
+
+- [Strapi Testing Proxy](#strapi-testing-proxy)
+  - [Table of Contents](#table-of-contents)
+  - [Setup and Configuration](#setup-and-configuration)
+    - [Prerequisites](#prerequisites)
+    - [Proxy Configuration](#proxy-configuration)
+  - [Running the Proxy Server](#running-the-proxy-server)
+    - [Starting the Proxy](#starting-the-proxy)
+    - [Infinite Mode](#infinite-mode)
+    - [Stopping the Proxy](#stopping-the-proxy)
+  - [Transferring Data to Your Local Database](#transferring-data-to-your-local-database)
+    - [Prerequisites](#prerequisites-1)
+    - [Data Transfer Steps](#data-transfer-steps)
+  - [Launch Frontend with Testing Backend](#launch-frontend-with-testing-backend)
+  - [Available Commands](#available-commands)
+  - [Common Issues and Troubleshooting](#common-issues-and-troubleshooting)
+    - [1. Logs and Debugging](#1-logs-and-debugging)
+    - [2. Token Expiration](#2-token-expiration)
+    - [3. Proxy Not Starting](#3-proxy-not-starting)
+  - [Additional Notes](#additional-notes)
+
+---
+
+## Setup and Configuration
+
+Before running the proxy server, ensure your environment is properly configured:
+
+### Prerequisites
+
+1. **Google Cloud SDK**
+
+   - Install the [Google Cloud SDK](https://cloud.google.com/sdk/docs/install) and configure it with your project:
+     ```bash
+     gcloud auth application-default login
+     gcloud config set project passculture-cls-metier-ehp
+     ```
+
+2. **iap-local-authentication**
+   - Clone the [iap-local-authentication](https://github.com/pass-culture/iap-local-authentication) repository at the same directory level as this project:
+     ```bash
+     git clone https://github.com/pass-culture/iap-local-authentication.git
+     ```
+3. **Python**
+   - Python3 is required to run iap-local-authentication
+
+### Proxy Configuration
+
+1. Launch the testing proxy server:
+
+   ```bash
+   yarn proxy:testing
+   ```
+
+   - This will open a browser window to log in via Google Cloud IAP.
+   - Once logged in, a Docker container will start, and the proxy will run at `http://localhost:8080`.
+
+2. Optional: Run the proxy server in **infinite mode** (to avoid token expiration every hour):
+   ```bash
+   yarn proxy:testing:infinite
+   ```
+
+---
+
+## Running the Proxy Server
+
+### Starting the Proxy
+
+- Run the following command to start the proxy:
+  ```bash
+  yarn proxy:testing
+  ```
+  - The proxy will authenticate via Google Cloud IAP and start at `http://localhost:8080`.
+
+### Infinite Mode
+
+- To automatically regenerate the JWT token every hour, run instead:
+  ```bash
+  yarn proxy:testing:infinite
+  ```
+
+### Stopping the Proxy
+
+- Stop the proxy server:
+  ```bash
+  yarn proxy:testing:stop
+  ```
+
+---
+
+## Transferring Data to Your Local Database
+
+Follow these steps to transfer data from the Strapi testing environment to your local database:
+
+### Prerequisites
+
+1. **Ensure your local database is running** and accessible. Refer to the instructions in the [content management system README](../content_management_system/README.md).
+
+### Data Transfer Steps
+
+1. Go to the [Strapi admin panel](https://siteinstit-cms.testing.passculture.team/admin/auth/login) of the remote testing environment.
+2. Navigate to **Settings > Transfer Tokens**.
+3. Create a **new transfer token** (Pull mode only) and copy it for later.
+
+4. Run the transfer script:
+
+   ```bash
+   yarn proxy:transfer
+   ```
+
+5. Enter the transfer token when prompted.
+6. The script will sync the data to your local database.
+
+---
+
+## Launch Frontend with Testing Backend
+
+To connect your frontend project (e.g., `public_website`) to the Strapi testing backend:
+
+1. Ensure the proxy is running at `http://localhost:8080`.
+2. Update the `.env` file in your frontend project with the following variable:
+   ```env
+   NEXT_PUBLIC_STRAPI_API_URL=http://localhost:8080
+   ```
+3. Restart your frontend development server:
+   ```bash
+   yarn dev
+   ```
+
+Your frontend should now point to the Strapi testing backend via the proxy.
+
+---
+
+## Available Commands
+
+All commands are available in the `package.json` file at **the root** of the project.
+
+| **Command**                   | **Description**                                              |
+| ----------------------------- | ------------------------------------------------------------ |
+| `yarn proxy:testing`          | Starts the proxy server to connect to Strapi.                |
+| `yarn proxy:testing:infinite` | Starts the proxy server in infinite mode (auto-refresh JWT). |
+| `yarn proxy:testing:stop`     | Stops the currently running proxy server.                    |
+| `yarn proxy:transfer`         | Transfers data from the remote testing server to local DB.   |
+
+---
+
+## Common Issues and Troubleshooting
+
+### 1. Logs and Debugging
+
+- If issues arise, check the logs for errors:
+  ```bash
+  docker logs <container_id>
+  ```
+
+### 2. Token Expiration
+
+- JWT tokens expire after 1 hour. Use **infinite mode** to avoid manual regeneration:
+  ```bash
+  yarn proxy:testing:infinite
+  ```
+
+### 3. Proxy Not Starting
+
+- Ensure Google Cloud SDK is installed and authenticated:
+  ```bash
+  gcloud auth application-default login
+  ```
+- Verify Docker is running and accessible.
+
+---
+
+## Additional Notes
+
+- This proxy setup is specifically for Strapi testing environment.
+- Ensure your environment variables and tokens are handled securely to avoid accidental leaks.

--- a/nginx-strapi-testing-proxy/launch-testing-proxy.sh
+++ b/nginx-strapi-testing-proxy/launch-testing-proxy.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# Script usage function
+usage() {
+  echo "⭐ Usage: $0 [-d AUTH_DIR] [-l true|false]"
+  echo "⭐   -d AUTH_DIR    Directory containing the get-iap-tokens.py script (default: ../../iap-local-authentication)"
+  echo "⭐                  Repository: https://github.com/pass-culture/iap-local-authentication"
+  echo "⭐   -l LOOP_MODE   Enable infinite loop to refresh JWT (true/false, default: false)"
+  exit 1
+}
+
+# Default values
+DEFAULT_AUTH_DIR="../../iap-local-authentication"
+CLOUDSDK_PYTHON="/usr/bin/python3"
+IMAGE_NAME="nginx-strapi-testing-proxy"
+CONTAINER_NAME="nginx-strapi-testing-proxy"
+VENV_DIR="venv"
+JWT_EXPIRATION_TIME=3600  # JWT valid for 1 hour (3600 seconds)
+LOOP_MODE=false
+
+# Parse command-line arguments
+while getopts "d:l:" opt; do
+  case $opt in
+    d) AUTH_DIR="$OPTARG" ;;
+    l) LOOP_MODE="$OPTARG" ;;
+    *) usage ;;
+  esac
+done
+
+# Use the default AUTH_DIR if none is provided
+AUTH_DIR=${AUTH_DIR:-$DEFAULT_AUTH_DIR}
+
+# Step 1: Create virtual environment and install dependencies
+echo "✨ Setting up the virtual environment and installing dependencies..."
+cd "$AUTH_DIR" || { echo "⚠️ Error: Cannot access $AUTH_DIR"; exit 1; }
+
+if [ ! -d "$VENV_DIR" ]; then
+  python3 -m venv "$VENV_DIR"
+  echo "⭐ Virtual environment created in $AUTH_DIR/$VENV_DIR."
+fi
+
+# Activate the virtual environment and install dependencies
+# shellcheck disable=SC1091
+source "$VENV_DIR/bin/activate"
+if [ -f "requirements.txt" ]; then
+  echo "🛠️ Installing dependencies from requirements.txt..."
+  pip install --upgrade pip
+  pip install -r requirements.txt || { echo "⚠️ Error: Failed to install dependencies."; exit 1; }
+else
+  echo "⚠️ Error: requirements.txt not found in $AUTH_DIR."
+  exit 1
+fi
+
+# Step 2: Google Cloud authentication
+echo "💳 Authenticating with Google Cloud..."
+export CLOUDSDK_PYTHON="$CLOUDSDK_PYTHON"
+
+gcloud auth application-default login || { echo "⚠️ Error: Google Cloud authentication failed"; exit 1; }
+
+# Step 3: Generate the IAP token
+generate_jwt() {
+  echo "✨ Generating the IAP token..."
+  python3 get-iap-tokens.py || { echo "⚠️ Error: Failed to generate IAP token."; exit 1; }
+
+  # Load environment variables containing the token
+  echo "📂 Loading IAP credentials..."
+  # shellcheck disable=SC1090
+  source ~/.iap-credentials || { echo "⚠️ Error: Unable to load ~/.iap-credentials"; exit 1; }
+
+  # Verify that the IAP_ID_TOKEN is set
+  if [ -z "$IAP_ID_TOKEN" ]; then
+    echo "⚠️ Error: IAP_ID_TOKEN is empty. Check the get-iap-tokens.py script."
+    exit 1
+  fi
+}
+
+generate_jwt
+
+# Return to the Docker directory
+echo "👉 Returning to the Docker directory..."
+deactivate
+cd - >/dev/null || exit 1
+
+# Step 4: Build the Docker image
+echo "🔧 Building the Docker image..."
+docker build -t "$IMAGE_NAME" . || { echo "⚠️ Error: Docker build failed"; exit 1; }
+
+# Step 5: Run the Docker container
+start_container() {
+  echo "🚀 Running the Docker container..."
+  docker stop "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  docker run -d --rm -p 8080:8080 -e IAP_ID_TOKEN="$IAP_ID_TOKEN" --name "$CONTAINER_NAME" "$IMAGE_NAME" || {
+    echo "⚠️ Error: Docker container failed to start"; exit 1;
+  }
+  echo "🎉 Container $CONTAINER_NAME is now running on port 8080. (http://localhost:8080/)"
+}
+
+start_container
+
+# Step 6: Infinite loop for JWT refresh if enabled
+if [ "$LOOP_MODE" = "true" ]; then
+  echo "🔄 Infinite loop mode enabled. Monitoring JWT expiration..."
+  while true; do
+    sleep $((JWT_EXPIRATION_TIME - 60))  # Refresh 1 minute before expiration
+
+    echo "⏳ JWT about to expire. Regenerating..."
+    generate_jwt
+
+    echo "⟳ Restarting container with new JWT..."
+    start_container
+  done
+else
+  echo "✅ Infinite loop mode disabled. Script execution complete."
+fi

--- a/nginx-strapi-testing-proxy/nginx.conf
+++ b/nginx-strapi-testing-proxy/nginx.conf
@@ -1,0 +1,17 @@
+events {}
+
+http {
+    server {
+        listen 8080;
+
+        location / {
+            proxy_pass https://siteinstit-cms.testing.passculture.team/;
+            
+            proxy_set_header Proxy-Authorization "Bearer $IAP_ID_TOKEN";
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_pass_request_headers on;
+        }
+    }
+}

--- a/nginx-strapi-testing-proxy/transfer-from-testing.sh
+++ b/nginx-strapi-testing-proxy/transfer-from-testing.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Configuration
+CONTAINER_NAME="nginx-strapi-testing-proxy"
+PROXY_URL="http://localhost:8080/admin"
+TRANSFER_COMMAND="yarn strapi transfer --from $PROXY_URL --exclude files"
+
+# Step 1: Check if the Docker container is running
+echo "Checking if the Docker proxy container '$CONTAINER_NAME' is running..."
+
+if docker ps --filter "name=$CONTAINER_NAME" --format "{{.Names}}" | grep -q "$CONTAINER_NAME"; then
+  echo "✅ Docker proxy container '$CONTAINER_NAME' is running."
+else
+  echo "❌ Error: Docker proxy container '$CONTAINER_NAME' is not running."
+  echo "Please start the proxy container before running this command."
+  echo "=> yarn proxy:testing"
+  exit 1
+fi
+
+# Step 2: Execute the transfer command
+cd ../content_management_system >/dev/null || exit 1
+echo "Executing the Strapi transfer command..."
+if $TRANSFER_COMMAND; then
+  echo "✅ Strapi transfer completed successfully."
+else
+  echo "❌ Error: Strapi transfer failed. Please check the logs for details."
+  exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -17,7 +17,11 @@
     "test:deadcode:update": "yarn --silent test:deadcode > scripts/dead_code_snapshot.txt",
     "test:lint": "concurrently \"cd public_website && yarn test:lint\" \"cd content_management_system && yarn test:lint\"",
     "test:types": "concurrently \"cd public_website && yarn test:types\" \"cd content_management_system && yarn test:types\"",
-    "copytypes": "node copyTypes.js"
+    "copytypes": "node copyTypes.js",
+    "proxy:testing": "cd nginx-strapi-testing-proxy && bash launch-testing-proxy.sh",
+    "proxy:testing:infinite": "cd nginx-strapi-testing-proxy && bash launch-testing-proxy.sh -l true",
+    "proxy:testing:stop": "docker stop nginx-strapi-testing-proxy",
+    "proxy:transfer": "cd nginx-strapi-testing-proxy && bash transfer-from-testing.sh"
   },
   "devDependencies": {
     "concurrently": "^9.0.0"

--- a/public_website/src/lib/analytics/analyticsProvider.ts
+++ b/public_website/src/lib/analytics/analyticsProvider.ts
@@ -29,7 +29,7 @@ export type EventMap = {
   pageView: { origin: string }
 }
 
-export const eventMapKeys: { [K in keyof EventMap]: true } = {
+export const eventMapKeys = {
   testEvent: true,
   goToSignUpNative: true,
   goToSignUpPro: true,


### PR DESCRIPTION
## Contexte

Cette Pull Request introduit un **proxy Nginx** pour faciliter la connexion au **Strapi de l'environnement de testing**, sécurisé derrière **Google Cloud IAP**.

L'objectif principal est de :
1. Permettre aux développeurs de connecter facilement le **frontend local** au Strapi de testing sans configuration manuelle de l'accès IAP.
2. Faciliter le **transfert de données** depuis l'environnement de testing vers la base de données locale pour les phases de développement et de tests.

---

## Changements apportés

### Nouveau dossier ajouté :
- **`nginx-strapi-testing-proxy/`** : Contient les fichiers nécessaires pour configurer et lancer le proxy ainsi que pour transférer les données.

### Fichiers inclus :
| **Fichier**                 | **Description**                                                                 |
|-----------------------------|-------------------------------------------------------------------------------|
| `Dockerfile`                | Configuration de l'image Docker pour exécuter le serveur Nginx.               |
| `nginx.conf`                | Configuration Nginx pour servir de proxy vers le Strapi de testing.           |
| `launch-testing-proxy.sh`   | Script shell pour démarrer le proxy configuré correctement.                   |
| `transfer-from-testing.sh`  | Script shell pour transférer les données depuis l'environnement de testing.   |

---

### Explication des fonctionnalités :
1. **Proxy Nginx** :  
   Le **Dockerfile** et **nginx.conf** permettent de déployer un serveur Nginx agissant comme un proxy vers le Strapi de testing.  
   Le proxy s'authentifie via IAP pour établir la connexion sécurisée.

2. **Scripts Shell** :  
   - **`launch-testing-proxy.sh`** : Lance le proxy en utilisant une configuration prête à l'emploi.  
   - **`transfer-from-testing.sh`** : Automatise le transfert des données du Strapi distant vers la base de données locale.

3. **Ajout de nouvelles commandes `yarn`** dans le `package.json` pour simplifier l'utilisation :

| **Commande**                  | **Description**                                                                 |
|-------------------------------|-------------------------------------------------------------------------------|
| `yarn proxy:testing`          | Lance le proxy Nginx configuré pour accéder au Strapi de testing.              |
| `yarn proxy:testing:infinite` | Lance le proxy avec un renouvellement automatique du token JWT toutes les heures. |
| `yarn proxy:testing:stop`     | Arrête le conteneur Docker qui exécute le proxy Nginx.                         |
| `yarn proxy:transfer`         | Transfère les données du Strapi distant vers la base de données locale.        |

---

## Documentation

Le **README** a été mis à jour pour inclure :
- Instructions d'utilisation du **proxy Nginx**.
- Étapes détaillées pour le **transfert des données**.
- Configuration nécessaire pour pointer le **frontend local** vers le proxy afin de tester les interactions front-end/back-end.

---

## Bénéfices apportés

- **Gain de temps** pour les développeurs en éliminant les configurations manuelles d'accès IAP.
- **Simplification des tests front-end/back-end** grâce à une connexion sécurisée au Strapi de testing.
- **Transfert de données facilité** pour avoir un environnement local aligné avec celui de testing.
