### PR TITLE
feat(sentry): add sentry sample rate to 0.1

### DIFF
--- a/public_website/sentry.client.config.ts
+++ b/public_website/sentry.client.config.ts
@@ -9,6 +9,7 @@ Sentry.init({
   debug: false,
   replaysSessionSampleRate: 0.0,
   replaysOnErrorSampleRate: 0.1,
+  sampleRate: 0.1,
   integrations: [
     Sentry.replayIntegration({
       maskAllText: true,

--- a/public_website/sentry.edge.config.ts
+++ b/public_website/sentry.edge.config.ts
@@ -7,4 +7,5 @@ Sentry.init({
   dsn: 'https://243b7abda6774f78805e4684f77c6d9d@sentry.passculture.team/12',
   tracesSampleRate: 1,
   debug: false,
+  sampleRate: 0.1,
 })

--- a/public_website/sentry.server.config.ts
+++ b/public_website/sentry.server.config.ts
@@ -7,4 +7,5 @@ Sentry.init({
   dsn: 'https://243b7abda6774f78805e4684f77c6d9d@sentry.passculture.team/12',
   tracesSampleRate: 1,
   debug: false,
+  sampleRate: 0.1,
 })


### PR DESCRIPTION
Cette pull request introduit un paramétrage du taux d’échantillonnage (`sample rate`) à **0.1** pour Sentry, permettant de mieux contrôler la quantité de logs envoyés sans impacter la qualité du monitoring. Cette modification vise à optimiser la performance et la consommation des ressources.

### ✨ Modification principale
- Ajout d’un `sample rate` de `0.1` dans la configuration de Sentry afin de limiter la remontée d’événements tout en conservant une visibilité suffisante sur les erreurs en production.

### 🎨 Impact
- **Optimisation des performances** : Moins de requêtes envoyées à Sentry, réduisant ainsi la charge réseau et le stockage des logs.
- **Réduction des coûts** : Une diminution du volume d’événements traités par Sentry, limitant les coûts liés à la gestion des logs.
- **Maintien de la visibilité** : Un échantillonnage équilibré permettant d’avoir une vue représentative des erreurs tout en évitant une surcharge inutile.

Cette mise à jour permet une meilleure gestion des logs et améliore l’efficacité globale du monitoring sur Sentry.

