### PR TITLE
feat(simulator): add ability to disable simulator

### DIFF
--- a/.github/workflows/on_dispatch_deploy_cms_production.yml
+++ b/.github/workflows/on_dispatch_deploy_cms_production.yml
@@ -1,0 +1,23 @@
+on:
+  workflow_dispatch:
+
+name: Deploy production CMS
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy-cms-production:
+    uses: ./.github/workflows/reusable_cms_deploy.yml
+    with:
+      project_id: passculture-cls-metier-prod
+      environment: production
+      workload_identity_provider_secret_name: passculture-cls-metier-ehp/gcp_cls_metier_prod_workload_identity_provider
+      cluster_scope: cls-metier
+      cluster_environment: prod
+      image_tag: ${{ github.sha }}
+      secrets_project_id: passculture-cls-metier-ehp
+    secrets:
+      SECRETS_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_CLS_EHP_WORKLOAD_IDENTITY_PROVIDER }}
+      SECRETS_SERVICE_ACCOUNT: ${{ secrets.GCP_CLS_EHP_SERVICE_ACCOUNT }}

--- a/content_management_system/src/api/simulator/content-types/simulator/schema.json
+++ b/content_management_system/src/api/simulator/content-types/simulator/schema.json
@@ -128,6 +128,15 @@
       "max": 1,
       "default": 0.5,
       "min": 0
+    },
+    "disableSimulator": {
+      "type": "boolean",
+      "default": false,
+      "required": true
+    },
+    "disableText": {
+      "type": "text",
+      "required": true
     }
   }
 }

--- a/content_management_system/types/generated/components.d.ts
+++ b/content_management_system/types/generated/components.d.ts
@@ -1,10 +1,165 @@
-import type { Schema, Attribute } from "@strapi/strapi";
+import type { Schema, Attribute } from '@strapi/strapi';
+
+export interface HomeRecommendationsSection extends Schema.Component {
+  collectionName: 'components_home_recommendations_sections';
+  info: {
+    displayName: 'recommendationsSection';
+  };
+  attributes: {
+    recommendations: Attribute.Component<'block.vertical-carousel'> &
+      Attribute.Required;
+    recommendationsBackendTag: Attribute.String & Attribute.Required;
+    cta: Attribute.Component<'common.link'> & Attribute.Required;
+  };
+}
+
+export interface HomeHeroSection extends Schema.Component {
+  collectionName: 'components_home_hero_sections';
+  info: {
+    displayName: 'heroSection';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.Text & Attribute.Required;
+    subTitle: Attribute.String & Attribute.Required;
+    cta: Attribute.Component<'common.link'> & Attribute.Required;
+    firstEmoji: Attribute.String & Attribute.Required;
+    secondEmoji: Attribute.String & Attribute.Required;
+    thirdEmoji: Attribute.String & Attribute.Required;
+    fourthEmoji: Attribute.String & Attribute.Required;
+    images: Attribute.Media<'images', true> & Attribute.Required;
+    fifthEmoji: Attribute.String & Attribute.Required;
+    sixthEmoji: Attribute.String & Attribute.Required;
+  };
+}
+
+export interface HomeEligibilitySection extends Schema.Component {
+  collectionName: 'components_home_eligibility_sections';
+  info: {
+    displayName: 'eligibilitySection';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    items: Attribute.Component<'home.eligibility-items', true> &
+      Attribute.Required;
+    cardTitle: Attribute.Text & Attribute.Required;
+    cardDescription: Attribute.String & Attribute.Required;
+    cardCta: Attribute.Component<'common.link'> & Attribute.Required;
+    firstEmoji: Attribute.String & Attribute.Required;
+    secondEmoji: Attribute.String & Attribute.Required;
+  };
+}
+
+export interface HomeEligibilityItems extends Schema.Component {
+  collectionName: 'components_home_eligibility_items';
+  info: {
+    displayName: 'eligibilityItems';
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    description: Attribute.String & Attribute.Required;
+    emoji: Attribute.String & Attribute.Required;
+  };
+}
+
+export interface SimulatorSuccessScreen extends Schema.Component {
+  collectionName: 'components_simulator_success_screens';
+  info: {
+    displayName: 'Success Screen';
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    steps: Attribute.Component<'simulator.step', true> & Attribute.Required;
+    cta: Attribute.Component<'common.link'> & Attribute.Required;
+    needSupport: Attribute.String & Attribute.Required;
+    supportLink: Attribute.Component<'common.link'> & Attribute.Required;
+  };
+}
+
+export interface SimulatorStep extends Schema.Component {
+  collectionName: 'components_simulator_steps';
+  info: {
+    displayName: 'Step';
+  };
+  attributes: {
+    step: Attribute.String & Attribute.Required;
+  };
+}
+
+export interface SimulatorRadioQuestion extends Schema.Component {
+  collectionName: 'components_simulator_radio_questions';
+  info: {
+    displayName: 'RadioQuestion';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    answers: Attribute.Component<'simulator.answer', true> &
+      Attribute.Required &
+      Attribute.SetMinMax<
+        {
+          min: 2;
+          max: 2;
+        },
+        number
+      >;
+  };
+}
+
+export interface SimulatorFailureScreen extends Schema.Component {
+  collectionName: 'components_simulator_failure_screens';
+  info: {
+    displayName: 'Failure Screen';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    text: Attribute.Text & Attribute.Required;
+    cta: Attribute.Component<'common.link'> & Attribute.Required;
+  };
+}
+
+export interface SimulatorAnswer extends Schema.Component {
+  collectionName: 'components_simulator_answers';
+  info: {
+    displayName: 'Answer';
+    description: '';
+  };
+  attributes: {
+    answer: Attribute.String & Attribute.Required;
+    emoji: Attribute.String;
+  };
+}
+
+export interface SimulatorAmountScreen extends Schema.Component {
+  collectionName: 'components_simulator_amount_screens';
+  info: {
+    displayName: 'Amount Screen';
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    text: Attribute.Text & Attribute.Required;
+  };
+}
+
+export interface SimulatorAgeQuestion extends Schema.Component {
+  collectionName: 'components_simulator_age_questions';
+  info: {
+    displayName: 'AgeQuestion';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    answers: Attribute.Component<'simulator.answer', true> & Attribute.Required;
+  };
+}
 
 export interface SharedSeo extends Schema.Component {
-  collectionName: "components_shared_seos";
+  collectionName: 'components_shared_seos';
   info: {
-    displayName: "seo";
-    icon: "search";
+    displayName: 'seo';
+    icon: 'search';
   };
   attributes: {
     metaTitle: Attribute.String &
@@ -18,8 +173,8 @@ export interface SharedSeo extends Schema.Component {
         minLength: 50;
         maxLength: 160;
       }>;
-    metaImage: Attribute.Media<"images" | "files" | "videos">;
-    metaSocial: Attribute.Component<"shared.meta-social", true>;
+    metaImage: Attribute.Media<'images' | 'files' | 'videos'>;
+    metaSocial: Attribute.Component<'shared.meta-social', true>;
     keywords: Attribute.Text;
     metaRobots: Attribute.String;
     structuredData: Attribute.JSON;
@@ -29,13 +184,13 @@ export interface SharedSeo extends Schema.Component {
 }
 
 export interface SharedMetaSocial extends Schema.Component {
-  collectionName: "components_shared_meta_socials";
+  collectionName: 'components_shared_meta_socials';
   info: {
-    displayName: "metaSocial";
-    icon: "project-diagram";
+    displayName: 'metaSocial';
+    icon: 'project-diagram';
   };
   attributes: {
-    socialNetwork: Attribute.Enumeration<["Facebook", "X"]> &
+    socialNetwork: Attribute.Enumeration<['Facebook', 'X']> &
       Attribute.Required;
     title: Attribute.String &
       Attribute.Required &
@@ -47,379 +202,29 @@ export interface SharedMetaSocial extends Schema.Component {
       Attribute.SetMinMaxLength<{
         maxLength: 65;
       }>;
-    image: Attribute.Media<"images" | "files" | "videos">;
+    image: Attribute.Media<'images' | 'files' | 'videos'>;
   };
-}
-
-export interface SimulatorSuccessScreen extends Schema.Component {
-  collectionName: "components_simulator_success_screens";
-  info: {
-    displayName: "Success Screen";
-  };
-  attributes: {
-    title: Attribute.String & Attribute.Required;
-    steps: Attribute.Component<"simulator.step", true> & Attribute.Required;
-    cta: Attribute.Component<"common.link"> & Attribute.Required;
-    needSupport: Attribute.String & Attribute.Required;
-    supportLink: Attribute.Component<"common.link"> & Attribute.Required;
-  };
-}
-
-export interface SimulatorStep extends Schema.Component {
-  collectionName: "components_simulator_steps";
-  info: {
-    displayName: "Step";
-  };
-  attributes: {
-    step: Attribute.String & Attribute.Required;
-  };
-}
-
-export interface SimulatorRadioQuestion extends Schema.Component {
-  collectionName: "components_simulator_radio_questions";
-  info: {
-    displayName: "RadioQuestion";
-    description: "";
-  };
-  attributes: {
-    title: Attribute.String & Attribute.Required;
-    answers: Attribute.Component<"simulator.answer", true> &
-      Attribute.Required &
-      Attribute.SetMinMax<
-        {
-          min: 2;
-          max: 2;
-        },
-        number
-      >;
-  };
-}
-
-export interface SimulatorFailureScreen extends Schema.Component {
-  collectionName: "components_simulator_failure_screens";
-  info: {
-    displayName: "Failure Screen";
-    description: "";
-  };
-  attributes: {
-    title: Attribute.String & Attribute.Required;
-    text: Attribute.Text & Attribute.Required;
-    cta: Attribute.Component<"common.link"> & Attribute.Required;
-  };
-}
-
-export interface SimulatorAnswer extends Schema.Component {
-  collectionName: "components_simulator_answers";
-  info: {
-    displayName: "Answer";
-    description: "";
-  };
-  attributes: {
-    answer: Attribute.String & Attribute.Required;
-    emoji: Attribute.String;
-  };
-}
-
-export interface SimulatorAmountScreen extends Schema.Component {
-  collectionName: "components_simulator_amount_screens";
-  info: {
-    displayName: "Amount Screen";
-  };
-  attributes: {
-    title: Attribute.String & Attribute.Required;
-    text: Attribute.Text & Attribute.Required;
-  };
-}
-
-export interface SimulatorAgeQuestion extends Schema.Component {
-  collectionName: "components_simulator_age_questions";
-  info: {
-    displayName: "AgeQuestion";
-    description: "";
-  };
-  attributes: {
-    title: Attribute.String & Attribute.Required;
-    answers: Attribute.Component<"simulator.answer", true> & Attribute.Required;
-  };
-}
-
-export interface HeaderNavigationItems extends Schema.Component {
-  collectionName: "components_header_navigation_items";
-  info: {
-    displayName: "navigationItems";
-  };
-  attributes: {
-    label: Attribute.String & Attribute.Required;
-    megaMenu: Attribute.Component<"header.mega-menu">;
-  };
-}
-
-export interface HeaderMegaMenu extends Schema.Component {
-  collectionName: "components_header_mega_menus";
-  info: {
-    displayName: "megaMenu";
-    description: "";
-  };
-  attributes: {
-    title: Attribute.String & Attribute.Required;
-    primaryListItems: Attribute.Component<"common.link", true> &
-      Attribute.Required;
-    secondaryListItems: Attribute.Component<"common.link", true>;
-    cta: Attribute.Component<"common.link"> & Attribute.Required;
-    cardTitle: Attribute.String & Attribute.Required;
-    cardDescription: Attribute.String & Attribute.Required;
-    cardLink: Attribute.Component<"common.link"> & Attribute.Required;
-    bannerText: Attribute.String;
-    cardFirstEmoji: Attribute.String & Attribute.Required;
-    cardSecondEmoji: Attribute.String & Attribute.Required;
-    bannerAndroidUrl: Attribute.String;
-    bannerIosUrl: Attribute.String;
-    bannerDefaultUrl: Attribute.String;
-    theme: Attribute.Enumeration<
-      [
-        "purple",
-        "yellow",
-        "magenta",
-        "orange",
-        "green",
-        "gold",
-        "sky",
-        "lila",
-        "deeppink",
-        "aquamarine",
-        "lightgray",
-        "saumon"
-      ]
-    > &
-      Attribute.DefaultTo<"gold">;
-  };
-}
-
-export interface HeaderLogin extends Schema.Component {
-  collectionName: "components_header_logins";
-  info: {
-    displayName: "login";
-  };
-  attributes: {
-    buttonLabel: Attribute.String & Attribute.Required;
-    loginItems: Attribute.Component<"header.login-items", true> &
-      Attribute.SetMinMax<
-        {
-          max: 2;
-        },
-        number
-      >;
-  };
-}
-
-export interface HeaderLoginItems extends Schema.Component {
-  collectionName: "components_header_login_items";
-  info: {
-    displayName: "loginItems";
-    description: "";
-  };
-  attributes: {
-    label: Attribute.String & Attribute.Required;
-    color: Attribute.String & Attribute.Required;
-    emoji: Attribute.String & Attribute.Required;
-    url: Attribute.String & Attribute.Required;
-    eventName: Attribute.Enumeration<
-      [
-        "goToSignUpNative",
-        "goToSignUpPro",
-        "goToLoginNative",
-        "goToLoginPro",
-        "downloadApp",
-        "goToFaqNative",
-        "goToFaqPro",
-        "contactSupport"
-      ]
-    >;
-    eventOrigin: Attribute.Enumeration<
-      [
-        "header",
-        "home",
-        "menu-young-people-and-parents",
-        "menu-pros",
-        "get-your-credit",
-        "essential-pros",
-        "how-to-propose-offers",
-        "help-young-people-and-parents",
-        "help-pros",
-        "help-teachers",
-        "simulator",
-        "parents",
-        "footer"
-      ]
-    >;
-  };
-}
-
-export interface HeaderHeader extends Schema.Component {
-  collectionName: "components_header_headers";
-  info: {
-    displayName: "header";
-  };
-  attributes: {};
-}
-
-export interface HeaderAccountItem extends Schema.Component {
-  collectionName: "components_header_account_item";
-  info: {
-    displayName: "accountItem";
-    description: "";
-  };
-  attributes: {
-    label: Attribute.String & Attribute.Required;
-    color: Attribute.String & Attribute.Required;
-    emoji: Attribute.String & Attribute.Required;
-    url: Attribute.String & Attribute.Required;
-    eventName: Attribute.Enumeration<
-      [
-        "goToSignUpNative",
-        "goToSignUpPro",
-        "goToLoginNative",
-        "goToLoginPro",
-        "downloadApp",
-        "goToFaqNative",
-        "goToFaqPro",
-        "contactSupport"
-      ]
-    >;
-    eventOrigin: Attribute.Enumeration<
-      [
-        "header",
-        "home",
-        "menu-young-people-and-parents",
-        "menu-pros",
-        "get-your-credit",
-        "essential-pros",
-        "how-to-propose-offers",
-        "help-young-people-and-parents",
-        "help-pros",
-        "help-teachers",
-        "simulator",
-        "parents",
-        "footer"
-      ]
-    >;
-  };
-}
-
-export interface HeaderAccountDropdown extends Schema.Component {
-  collectionName: "components_header_account_dropdowns";
-  info: {
-    displayName: "accountDropdown";
-  };
-  attributes: {
-    buttonLabel: Attribute.String & Attribute.Required;
-    items: Attribute.Component<"header.account-item", true> &
-      Attribute.Required;
-  };
-}
-
-export interface HomeRecommendationsSection extends Schema.Component {
-  collectionName: "components_home_recommendations_sections";
-  info: {
-    displayName: "recommendationsSection";
-  };
-  attributes: {
-    recommendations: Attribute.Component<"block.vertical-carousel"> &
-      Attribute.Required;
-    recommendationsBackendTag: Attribute.String & Attribute.Required;
-    cta: Attribute.Component<"common.link"> & Attribute.Required;
-  };
-}
-
-export interface HomeHeroSection extends Schema.Component {
-  collectionName: "components_home_hero_sections";
-  info: {
-    displayName: "heroSection";
-    description: "";
-  };
-  attributes: {
-    title: Attribute.Text & Attribute.Required;
-    subTitle: Attribute.String & Attribute.Required;
-    cta: Attribute.Component<"common.link"> & Attribute.Required;
-    firstEmoji: Attribute.String & Attribute.Required;
-    secondEmoji: Attribute.String & Attribute.Required;
-    thirdEmoji: Attribute.String & Attribute.Required;
-    fourthEmoji: Attribute.String & Attribute.Required;
-    images: Attribute.Media<"images", true> & Attribute.Required;
-    fifthEmoji: Attribute.String & Attribute.Required;
-    sixthEmoji: Attribute.String & Attribute.Required;
-  };
-}
-
-export interface HomeEligibilitySection extends Schema.Component {
-  collectionName: "components_home_eligibility_sections";
-  info: {
-    displayName: "eligibilitySection";
-    description: "";
-  };
-  attributes: {
-    title: Attribute.String & Attribute.Required;
-    items: Attribute.Component<"home.eligibility-items", true> &
-      Attribute.Required;
-    cardTitle: Attribute.Text & Attribute.Required;
-    cardDescription: Attribute.String & Attribute.Required;
-    cardCta: Attribute.Component<"common.link"> & Attribute.Required;
-    firstEmoji: Attribute.String & Attribute.Required;
-    secondEmoji: Attribute.String & Attribute.Required;
-  };
-}
-
-export interface HomeEligibilityItems extends Schema.Component {
-  collectionName: "components_home_eligibility_items";
-  info: {
-    displayName: "eligibilityItems";
-  };
-  attributes: {
-    title: Attribute.String & Attribute.Required;
-    description: Attribute.String & Attribute.Required;
-    emoji: Attribute.String & Attribute.Required;
-  };
-}
-
-export interface FooterList extends Schema.Component {
-  collectionName: "components_footer_lists";
-  info: {
-    displayName: "Lists";
-    description: "";
-  };
-  attributes: {
-    Title: Attribute.String & Attribute.Required;
-    Links: Attribute.Component<"common.link", true>;
-  };
-}
-
-export interface FooterLegalLinks extends Schema.Component {
-  collectionName: "components_footer_legal_links";
-  info: {
-    displayName: "LegalLinks";
-  };
-  attributes: {};
 }
 
 export interface CommonVerticalCarouselItem extends Schema.Component {
-  collectionName: "components_common_vertical_carousel_items";
+  collectionName: 'components_common_vertical_carousel_items';
   info: {
-    displayName: "verticalCarouselItem";
-    description: "";
+    displayName: 'verticalCarouselItem';
+    description: '';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
     description: Attribute.String & Attribute.Required;
     url: Attribute.String & Attribute.Required;
-    image: Attribute.Media<"images">;
+    image: Attribute.Media<'images'>;
   };
 }
 
 export interface CommonSimpleTextColumn extends Schema.Component {
-  collectionName: "components_common_simple_text_columns";
+  collectionName: 'components_common_simple_text_columns';
   info: {
-    displayName: "Simple Text Column";
-    description: "";
+    displayName: 'Simple Text Column';
+    description: '';
   };
   attributes: {
     title: Attribute.String;
@@ -428,56 +233,56 @@ export interface CommonSimpleTextColumn extends Schema.Component {
 }
 
 export interface CommonPiledCardItem extends Schema.Component {
-  collectionName: "components_common_piled_card_items";
+  collectionName: 'components_common_piled_card_items';
   info: {
-    displayName: "PiledCardItem";
-    description: "";
+    displayName: 'PiledCardItem';
+    description: '';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
     description: Attribute.Text & Attribute.Required;
-    image: Attribute.Media<"images"> & Attribute.Required;
+    image: Attribute.Media<'images'> & Attribute.Required;
     firstIcon: Attribute.String;
     secondIcon: Attribute.String;
     theme: Attribute.Enumeration<
       [
-        "purple",
-        "yellow",
-        "magenta",
-        "orange",
-        "green",
-        "blue",
-        "gold",
-        "sky",
-        "lila",
-        "deeppink",
-        "aquamarine",
-        "lightgray",
-        "saumon"
+        'purple',
+        'yellow',
+        'magenta',
+        'orange',
+        'green',
+        'blue',
+        'gold',
+        'sky',
+        'lila',
+        'deeppink',
+        'aquamarine',
+        'lightgray',
+        'saumon'
       ]
     > &
       Attribute.Required &
-      Attribute.DefaultTo<"purple">;
+      Attribute.DefaultTo<'purple'>;
   };
 }
 
 export interface CommonPerson extends Schema.Component {
-  collectionName: "components_common_people";
+  collectionName: 'components_common_people';
   info: {
-    displayName: "Person";
+    displayName: 'Person';
   };
   attributes: {
     name: Attribute.String & Attribute.Required;
     position: Attribute.String & Attribute.Required;
-    image: Attribute.Media<"images"> & Attribute.Required;
+    image: Attribute.Media<'images'> & Attribute.Required;
   };
 }
 
 export interface CommonOffers extends Schema.Component {
-  collectionName: "components_common_offers";
+  collectionName: 'components_common_offers';
   info: {
-    displayName: "Offers";
-    description: "";
+    displayName: 'Offers';
+    description: '';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
@@ -489,10 +294,10 @@ export interface CommonOffers extends Schema.Component {
 }
 
 export interface CommonOffersCarouselItem extends Schema.Component {
-  collectionName: "components_common_offers_carousel_items";
+  collectionName: 'components_common_offers_carousel_items';
   info: {
-    displayName: "OffersCarouselItem";
-    description: "";
+    displayName: 'OffersCarouselItem';
+    description: '';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
@@ -502,83 +307,83 @@ export interface CommonOffersCarouselItem extends Schema.Component {
     text: Attribute.Text & Attribute.Required;
     theme: Attribute.Enumeration<
       [
-        "purple",
-        "yellow",
-        "magenta",
-        "orange",
-        "green",
-        "gold",
-        "sky",
-        "lila",
-        "deeppink",
-        "aquamarine",
-        "lightgray",
-        "saumon"
+        'purple',
+        'yellow',
+        'magenta',
+        'orange',
+        'green',
+        'gold',
+        'sky',
+        'lila',
+        'deeppink',
+        'aquamarine',
+        'lightgray',
+        'saumon'
       ]
     > &
       Attribute.Required &
-      Attribute.DefaultTo<"purple">;
+      Attribute.DefaultTo<'purple'>;
   };
 }
 
 export interface CommonNotRequiredLink extends Schema.Component {
-  collectionName: "components_common_not_required_links";
+  collectionName: 'components_common_not_required_links';
   info: {
-    displayName: "NotRequiredLink";
-    description: "";
+    displayName: 'NotRequiredLink';
+    description: '';
   };
   attributes: {
     Label: Attribute.String & Attribute.Required;
     URL: Attribute.String & Attribute.Required;
     eventName: Attribute.Enumeration<
       [
-        "goToSignUpNative",
-        "goToSignUpPro",
-        "goToLoginNative",
-        "goToLoginPro",
-        "downloadApp",
-        "goToFaqNative",
-        "goToFaqPro",
-        "contactSupport"
+        'goToSignUpNative',
+        'goToSignUpPro',
+        'goToLoginNative',
+        'goToLoginPro',
+        'downloadApp',
+        'goToFaqNative',
+        'goToFaqPro',
+        'contactSupport'
       ]
     >;
     eventOrigin: Attribute.Enumeration<
       [
-        "header",
-        "home",
-        "menu-young-people-and-parents",
-        "menu-pros",
-        "get-your-credit",
-        "essential-pros",
-        "how-to-propose-offers",
-        "help-young-people-and-parents",
-        "help-pros",
-        "help-teachers",
-        "simulator",
-        "parents",
-        "footer"
+        'header',
+        'home',
+        'menu-young-people-and-parents',
+        'menu-pros',
+        'get-your-credit',
+        'essential-pros',
+        'how-to-propose-offers',
+        'help-young-people-and-parents',
+        'help-pros',
+        'help-teachers',
+        'simulator',
+        'parents',
+        'footer'
       ]
     >;
   };
 }
 
 export interface CommonLogo extends Schema.Component {
-  collectionName: "components_common_logos";
+  collectionName: 'components_common_logos';
   info: {
-    displayName: "Logo";
-    description: "";
+    displayName: 'Logo';
+    description: '';
   };
   attributes: {
-    logo: Attribute.Media<"images" | "files" | "videos" | "audios"> &
+    logo: Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
       Attribute.Required;
   };
 }
 
 export interface CommonLittleListComponent extends Schema.Component {
-  collectionName: "components_common_little_list_components";
+  collectionName: 'components_common_little_list_components';
   info: {
-    displayName: "LittleListComponent";
-    description: "";
+    displayName: 'LittleListComponent';
+    description: '';
   };
   attributes: {
     text: Attribute.Text & Attribute.Required;
@@ -589,50 +394,50 @@ export interface CommonLittleListComponent extends Schema.Component {
 }
 
 export interface CommonLink extends Schema.Component {
-  collectionName: "components_common_links";
+  collectionName: 'components_common_links';
   info: {
-    displayName: "Link";
-    description: "";
+    displayName: 'Link';
+    description: '';
   };
   attributes: {
     Label: Attribute.String & Attribute.Required;
     URL: Attribute.String & Attribute.Required;
     eventName: Attribute.Enumeration<
       [
-        "goToSignUpNative",
-        "goToSignUpPro",
-        "goToLoginNative",
-        "goToLoginPro",
-        "downloadApp",
-        "goToFaqNative",
-        "goToFaqPro",
-        "contactSupport"
+        'goToSignUpNative',
+        'goToSignUpPro',
+        'goToLoginNative',
+        'goToLoginPro',
+        'downloadApp',
+        'goToFaqNative',
+        'goToFaqPro',
+        'contactSupport'
       ]
     >;
     eventOrigin: Attribute.Enumeration<
       [
-        "header",
-        "home",
-        "menu-young-people-and-parents",
-        "menu-pros",
-        "get-your-credit",
-        "essential-pros",
-        "how-to-propose-offers",
-        "help-young-people-and-parents",
-        "help-pros",
-        "help-teachers",
-        "simulator",
-        "parents",
-        "footer"
+        'header',
+        'home',
+        'menu-young-people-and-parents',
+        'menu-pros',
+        'get-your-credit',
+        'essential-pros',
+        'how-to-propose-offers',
+        'help-young-people-and-parents',
+        'help-pros',
+        'help-teachers',
+        'simulator',
+        'parents',
+        'footer'
       ]
     >;
   };
 }
 
 export interface CommonKeyNumberItems extends Schema.Component {
-  collectionName: "components_common_key_number_items";
+  collectionName: 'components_common_key_number_items';
   info: {
-    displayName: "KeyNumberItems";
+    displayName: 'KeyNumberItems';
   };
   attributes: {
     firstEmoji: Attribute.String;
@@ -644,10 +449,10 @@ export interface CommonKeyNumberItems extends Schema.Component {
 }
 
 export interface CommonFiltre extends Schema.Component {
-  collectionName: "components_common_filtres";
+  collectionName: 'components_common_filtres';
   info: {
-    displayName: "Filtre";
-    description: "";
+    displayName: 'Filtre';
+    description: '';
   };
   attributes: {
     filtre: Attribute.String & Attribute.Required;
@@ -655,148 +460,343 @@ export interface CommonFiltre extends Schema.Component {
 }
 
 export interface CommonExperienceVideoCarouselItem extends Schema.Component {
-  collectionName: "components_common_experience_video_carousel_items";
+  collectionName: 'components_common_experience_video_carousel_items';
   info: {
-    displayName: "ExperienceVideoCarouselItem";
+    displayName: 'ExperienceVideoCarouselItem';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
     description: Attribute.String & Attribute.Required;
     url: Attribute.String;
-    image: Attribute.Media<"images">;
+    image: Attribute.Media<'images'>;
   };
 }
 
 export interface CommonDetailedLogo extends Schema.Component {
-  collectionName: "components_common_detailed_logos";
+  collectionName: 'components_common_detailed_logos';
   info: {
-    displayName: "Detailed Logo";
+    displayName: 'Detailed Logo';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
     description: Attribute.String & Attribute.Required;
-    cta: Attribute.Component<"common.link"> & Attribute.Required;
-    image: Attribute.Media<"images"> & Attribute.Required;
+    cta: Attribute.Component<'common.link'> & Attribute.Required;
+    image: Attribute.Media<'images'> & Attribute.Required;
+  };
+}
+
+export interface FooterList extends Schema.Component {
+  collectionName: 'components_footer_lists';
+  info: {
+    displayName: 'Lists';
+    description: '';
+  };
+  attributes: {
+    Title: Attribute.String & Attribute.Required;
+    Links: Attribute.Component<'common.link', true>;
+  };
+}
+
+export interface FooterLegalLinks extends Schema.Component {
+  collectionName: 'components_footer_legal_links';
+  info: {
+    displayName: 'LegalLinks';
+  };
+  attributes: {};
+}
+
+export interface HeaderNavigationItems extends Schema.Component {
+  collectionName: 'components_header_navigation_items';
+  info: {
+    displayName: 'navigationItems';
+  };
+  attributes: {
+    label: Attribute.String & Attribute.Required;
+    megaMenu: Attribute.Component<'header.mega-menu'>;
+  };
+}
+
+export interface HeaderMegaMenu extends Schema.Component {
+  collectionName: 'components_header_mega_menus';
+  info: {
+    displayName: 'megaMenu';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    primaryListItems: Attribute.Component<'common.link', true> &
+      Attribute.Required;
+    secondaryListItems: Attribute.Component<'common.link', true>;
+    cta: Attribute.Component<'common.link'> & Attribute.Required;
+    cardTitle: Attribute.String & Attribute.Required;
+    cardDescription: Attribute.String & Attribute.Required;
+    cardLink: Attribute.Component<'common.link'> & Attribute.Required;
+    bannerText: Attribute.String;
+    cardFirstEmoji: Attribute.String & Attribute.Required;
+    cardSecondEmoji: Attribute.String & Attribute.Required;
+    bannerAndroidUrl: Attribute.String;
+    bannerIosUrl: Attribute.String;
+    bannerDefaultUrl: Attribute.String;
+    theme: Attribute.Enumeration<
+      [
+        'purple',
+        'yellow',
+        'magenta',
+        'orange',
+        'green',
+        'gold',
+        'sky',
+        'lila',
+        'deeppink',
+        'aquamarine',
+        'lightgray',
+        'saumon'
+      ]
+    > &
+      Attribute.DefaultTo<'gold'>;
+  };
+}
+
+export interface HeaderLogin extends Schema.Component {
+  collectionName: 'components_header_logins';
+  info: {
+    displayName: 'login';
+  };
+  attributes: {
+    buttonLabel: Attribute.String & Attribute.Required;
+    loginItems: Attribute.Component<'header.login-items', true> &
+      Attribute.SetMinMax<
+        {
+          max: 2;
+        },
+        number
+      >;
+  };
+}
+
+export interface HeaderLoginItems extends Schema.Component {
+  collectionName: 'components_header_login_items';
+  info: {
+    displayName: 'loginItems';
+    description: '';
+  };
+  attributes: {
+    label: Attribute.String & Attribute.Required;
+    color: Attribute.String & Attribute.Required;
+    emoji: Attribute.String & Attribute.Required;
+    url: Attribute.String & Attribute.Required;
+    eventName: Attribute.Enumeration<
+      [
+        'goToSignUpNative',
+        'goToSignUpPro',
+        'goToLoginNative',
+        'goToLoginPro',
+        'downloadApp',
+        'goToFaqNative',
+        'goToFaqPro',
+        'contactSupport'
+      ]
+    >;
+    eventOrigin: Attribute.Enumeration<
+      [
+        'header',
+        'home',
+        'menu-young-people-and-parents',
+        'menu-pros',
+        'get-your-credit',
+        'essential-pros',
+        'how-to-propose-offers',
+        'help-young-people-and-parents',
+        'help-pros',
+        'help-teachers',
+        'simulator',
+        'parents',
+        'footer'
+      ]
+    >;
+  };
+}
+
+export interface HeaderHeader extends Schema.Component {
+  collectionName: 'components_header_headers';
+  info: {
+    displayName: 'header';
+  };
+  attributes: {};
+}
+
+export interface HeaderAccountItem extends Schema.Component {
+  collectionName: 'components_header_account_item';
+  info: {
+    displayName: 'accountItem';
+    description: '';
+  };
+  attributes: {
+    label: Attribute.String & Attribute.Required;
+    color: Attribute.String & Attribute.Required;
+    emoji: Attribute.String & Attribute.Required;
+    url: Attribute.String & Attribute.Required;
+    eventName: Attribute.Enumeration<
+      [
+        'goToSignUpNative',
+        'goToSignUpPro',
+        'goToLoginNative',
+        'goToLoginPro',
+        'downloadApp',
+        'goToFaqNative',
+        'goToFaqPro',
+        'contactSupport'
+      ]
+    >;
+    eventOrigin: Attribute.Enumeration<
+      [
+        'header',
+        'home',
+        'menu-young-people-and-parents',
+        'menu-pros',
+        'get-your-credit',
+        'essential-pros',
+        'how-to-propose-offers',
+        'help-young-people-and-parents',
+        'help-pros',
+        'help-teachers',
+        'simulator',
+        'parents',
+        'footer'
+      ]
+    >;
+  };
+}
+
+export interface HeaderAccountDropdown extends Schema.Component {
+  collectionName: 'components_header_account_dropdowns';
+  info: {
+    displayName: 'accountDropdown';
+  };
+  attributes: {
+    buttonLabel: Attribute.String & Attribute.Required;
+    items: Attribute.Component<'header.account-item', true> &
+      Attribute.Required;
   };
 }
 
 export interface BlockVideo extends Schema.Component {
-  collectionName: "components_block_videos";
+  collectionName: 'components_block_videos';
   info: {
-    displayName: "Video";
-    description: "";
+    displayName: 'Video';
+    description: '';
   };
   attributes: {
     url: Attribute.Text;
     description: Attribute.Text;
     alt: Attribute.Text;
-    image: Attribute.Media<"images" | "files" | "videos" | "audios">;
+    image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
   };
 }
 
 export interface BlockVerticalCarousel extends Schema.Component {
-  collectionName: "components_block_vertical_carousels";
+  collectionName: 'components_block_vertical_carousels';
   info: {
-    displayName: "VerticalCarousel";
-    description: "";
+    displayName: 'VerticalCarousel';
+    description: '';
   };
   attributes: {
     title: Attribute.Text & Attribute.Required;
-    items: Attribute.Component<"common.vertical-carousel-item", true> &
+    items: Attribute.Component<'common.vertical-carousel-item', true> &
       Attribute.Required;
   };
 }
 
 export interface BlockTabsSimpleText extends Schema.Component {
-  collectionName: "components_block_tabs_simple_texts";
+  collectionName: 'components_block_tabs_simple_texts';
   info: {
-    displayName: "TabsSimpleText";
+    displayName: 'TabsSimpleText';
   };
   attributes: {
-    tab: Attribute.Component<"block.tab-simple-text", true>;
+    tab: Attribute.Component<'block.tab-simple-text', true>;
   };
 }
 
 export interface BlockTabsPushGreyCta extends Schema.Component {
-  collectionName: "components_block_tabs_push_grey_ctas";
+  collectionName: 'components_block_tabs_push_grey_ctas';
   info: {
-    displayName: "TabsPushGreyCTA";
-    description: "";
+    displayName: 'TabsPushGreyCTA';
+    description: '';
   };
   attributes: {
-    tab: Attribute.Component<"block.tab-push-grey-cta", true>;
+    tab: Attribute.Component<'block.tab-push-grey-cta', true>;
   };
 }
 
 export interface BlockTabsLittleList extends Schema.Component {
-  collectionName: "components_block_tabs_little_lists";
+  collectionName: 'components_block_tabs_little_lists';
   info: {
-    displayName: "TabsLittleList";
+    displayName: 'TabsLittleList';
   };
   attributes: {
-    tab: Attribute.Component<"block.tab-little-list", true>;
+    tab: Attribute.Component<'block.tab-little-list', true>;
   };
 }
 
 export interface BlockTabsImageText extends Schema.Component {
-  collectionName: "components_block_tabs_image_texts";
+  collectionName: 'components_block_tabs_image_texts';
   info: {
-    displayName: "TabsImageText";
+    displayName: 'TabsImageText';
   };
   attributes: {
-    tab: Attribute.Component<"block.tab-image-text", true>;
+    tab: Attribute.Component<'block.tab-image-text', true>;
   };
 }
 
 export interface BlockTabSimpleText extends Schema.Component {
-  collectionName: "components_block_tab_simple_texts";
+  collectionName: 'components_block_tab_simple_texts';
   info: {
-    displayName: "TabSimpleText";
+    displayName: 'TabSimpleText';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
-    block: Attribute.Component<"block.simple-text-v2">;
+    block: Attribute.Component<'block.simple-text-v2'>;
   };
 }
 
 export interface BlockTabPushGreyCta extends Schema.Component {
-  collectionName: "components_block_tab_push_grey_ctas";
+  collectionName: 'components_block_tab_push_grey_ctas';
   info: {
-    displayName: "TabPushGreyCTA";
+    displayName: 'TabPushGreyCTA';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
-    block: Attribute.Component<"block.double-push-cta">;
+    block: Attribute.Component<'block.double-push-cta'>;
   };
 }
 
 export interface BlockTabLittleList extends Schema.Component {
-  collectionName: "components_block_tab_little_lists";
+  collectionName: 'components_block_tab_little_lists';
   info: {
-    displayName: "TabLittleList";
+    displayName: 'TabLittleList';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
-    block: Attribute.Component<"block.little-list">;
+    block: Attribute.Component<'block.little-list'>;
   };
 }
 
 export interface BlockTabImageText extends Schema.Component {
-  collectionName: "components_block_tab_image_texts";
+  collectionName: 'components_block_tab_image_texts';
   info: {
-    displayName: "TabImageText";
+    displayName: 'TabImageText';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
-    block: Attribute.Component<"block.image-text">;
+    block: Attribute.Component<'block.image-text'>;
   };
 }
 
 export interface BlockSpace extends Schema.Component {
-  collectionName: "components_block_spaces";
+  collectionName: 'components_block_spaces';
   info: {
-    displayName: "Space";
-    description: "";
+    displayName: 'Space';
+    description: '';
   };
   attributes: {
     space: Attribute.Integer;
@@ -804,28 +804,28 @@ export interface BlockSpace extends Schema.Component {
 }
 
 export interface BlockSocialMedia extends Schema.Component {
-  collectionName: "components_block_social_medias";
+  collectionName: 'components_block_social_medias';
   info: {
-    displayName: "socialMedia";
-    description: "";
+    displayName: 'socialMedia';
+    description: '';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
-    socialMediaLink: Attribute.Component<"block.link", true> &
+    socialMediaLink: Attribute.Component<'block.link', true> &
       Attribute.Required;
   };
 }
 
 export interface BlockSimpleTextV2 extends Schema.Component {
-  collectionName: "components_block_simple_text_v2s";
+  collectionName: 'components_block_simple_text_v2s';
   info: {
-    displayName: "Simple Text";
-    description: "";
+    displayName: 'Simple Text';
+    description: '';
   };
   attributes: {
     title: Attribute.String;
     text: Attribute.Blocks & Attribute.Required;
-    columns: Attribute.Component<"common.simple-text-column", true> &
+    columns: Attribute.Component<'common.simple-text-column', true> &
       Attribute.SetMinMax<
         {
           max: 2;
@@ -836,26 +836,26 @@ export interface BlockSimpleTextV2 extends Schema.Component {
 }
 
 export interface BlockSimplePushCta extends Schema.Component {
-  collectionName: "components_block_simple_push_ctas";
+  collectionName: 'components_block_simple_push_ctas';
   info: {
-    displayName: "Push Blue CTA";
-    description: "";
+    displayName: 'Push Blue CTA';
+    description: '';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
     surtitle: Attribute.String & Attribute.Required;
-    image: Attribute.Media<"images" | "files" | "videos" | "audios"> &
+    image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
       Attribute.Required;
-    cta: Attribute.Component<"common.link"> & Attribute.Required;
+    cta: Attribute.Component<'common.link'> & Attribute.Required;
     icon: Attribute.String;
   };
 }
 
 export interface BlockSeparator extends Schema.Component {
-  collectionName: "components_block_separators";
+  collectionName: 'components_block_separators';
   info: {
-    displayName: "Separator";
-    description: "";
+    displayName: 'Separator';
+    description: '';
   };
   attributes: {
     isActive: Attribute.Boolean &
@@ -865,133 +865,133 @@ export interface BlockSeparator extends Schema.Component {
 }
 
 export interface BlockRelatedNews extends Schema.Component {
-  collectionName: "components_block_related_news";
+  collectionName: 'components_block_related_news';
   info: {
-    displayName: "RelatedNews";
-    description: "";
+    displayName: 'RelatedNews';
+    description: '';
   };
   attributes: {
     title: Attribute.String;
-    cta: Attribute.Component<"common.link">;
+    cta: Attribute.Component<'common.link'>;
   };
 }
 
 export interface BlockPushCta extends Schema.Component {
-  collectionName: "components_block_push_ctas";
+  collectionName: 'components_block_push_ctas';
   info: {
-    displayName: "Push CTA With QrCode";
-    description: "";
+    displayName: 'Push CTA With QrCode';
+    description: '';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
     description: Attribute.Text;
-    image: Attribute.Media<"images"> & Attribute.Required;
-    ctaLink: Attribute.Component<"common.link"> & Attribute.Required;
+    image: Attribute.Media<'images'> & Attribute.Required;
+    ctaLink: Attribute.Component<'common.link'> & Attribute.Required;
     qrCodeDescription: Attribute.String & Attribute.Required;
     qrCodeUrl: Attribute.String & Attribute.Required;
   };
 }
 
 export interface BlockPiledCards extends Schema.Component {
-  collectionName: "components_block_piled_cards";
+  collectionName: 'components_block_piled_cards';
   info: {
-    displayName: "PiledCards";
-    description: "";
+    displayName: 'PiledCards';
+    description: '';
   };
   attributes: {
-    items: Attribute.Component<"common.piled-card-item", true>;
+    items: Attribute.Component<'common.piled-card-item', true>;
     accessibleTitle: Attribute.String & Attribute.Required;
   };
 }
 
 export interface BlockOrganizationChart extends Schema.Component {
-  collectionName: "components_block_organization_charts";
+  collectionName: 'components_block_organization_charts';
   info: {
-    displayName: "Organization Chart";
-    description: "";
+    displayName: 'Organization Chart';
+    description: '';
   };
   attributes: {
     title: Attribute.String;
     description: Attribute.Text & Attribute.Required;
-    people: Attribute.Component<"common.person", true> & Attribute.Required;
+    people: Attribute.Component<'common.person', true> & Attribute.Required;
   };
 }
 
 export interface BlockOffersSection extends Schema.Component {
-  collectionName: "components_block_offers_sections";
+  collectionName: 'components_block_offers_sections';
   info: {
-    displayName: "OffersSection";
-    description: "";
+    displayName: 'OffersSection';
+    description: '';
   };
   attributes: {
-    offers: Attribute.Component<"common.offers">;
+    offers: Attribute.Component<'common.offers'>;
     offerTag: Attribute.String;
-    cta: Attribute.Component<"common.link">;
+    cta: Attribute.Component<'common.link'>;
     firstCardtitle: Attribute.String & Attribute.Required;
     secondCardTitle: Attribute.String & Attribute.Required;
     descriptionCard: Attribute.Text & Attribute.Required;
     firstCardIcon: Attribute.String;
     secondCardIcon: Attribute.String;
-    cardCta: Attribute.Component<"common.link">;
+    cardCta: Attribute.Component<'common.link'>;
   };
 }
 
 export interface BlockOffersCarousel extends Schema.Component {
-  collectionName: "components_block_offers_carousels";
+  collectionName: 'components_block_offers_carousels';
   info: {
-    displayName: "OffersCarousel";
-    description: "";
+    displayName: 'OffersCarousel';
+    description: '';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
-    items: Attribute.Component<"common.offers-carousel-item", true> &
+    items: Attribute.Component<'common.offers-carousel-item', true> &
       Attribute.Required;
-    cta: Attribute.Component<"common.link"> & Attribute.Required;
+    cta: Attribute.Component<'common.link'> & Attribute.Required;
     description: Attribute.Blocks;
   };
 }
 
 export interface BlockOfferList extends Schema.Component {
-  collectionName: "components_block_offer_lists";
+  collectionName: 'components_block_offer_lists';
   info: {
-    displayName: "OfferList";
-    description: "";
+    displayName: 'OfferList';
+    description: '';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
     description: Attribute.String & Attribute.Required;
     offreTag: Attribute.String & Attribute.Required;
-    cta: Attribute.Component<"common.link"> & Attribute.Required;
+    cta: Attribute.Component<'common.link'> & Attribute.Required;
     firstCartTitle: Attribute.String & Attribute.Required;
     secondCartTitle: Attribute.String & Attribute.Required;
     descritptionCard: Attribute.Text & Attribute.Required;
     firstIcon: Attribute.String & Attribute.Required;
     secondIcon: Attribute.String & Attribute.Required;
-    ctaCard: Attribute.Component<"common.link"> & Attribute.Required;
+    ctaCard: Attribute.Component<'common.link'> & Attribute.Required;
   };
 }
 
 export interface BlockLogos extends Schema.Component {
-  collectionName: "components_block_logos";
+  collectionName: 'components_block_logos';
   info: {
-    displayName: "Logos";
-    description: "";
+    displayName: 'Logos';
+    description: '';
   };
   attributes: {
-    logo: Attribute.Component<"common.logo", true>;
+    logo: Attribute.Component<'common.logo', true>;
   };
 }
 
 export interface BlockLittleList extends Schema.Component {
-  collectionName: "components_block_little_lists";
+  collectionName: 'components_block_little_lists';
   info: {
-    displayName: "LittleList";
-    description: "";
+    displayName: 'LittleList';
+    description: '';
   };
   attributes: {
     title: Attribute.String;
     description: Attribute.Text;
-    content: Attribute.Component<"common.little-list-component", true> &
+    content: Attribute.Component<'common.little-list-component', true> &
       Attribute.SetMinMax<
         {
           max: 4;
@@ -1002,21 +1002,21 @@ export interface BlockLittleList extends Schema.Component {
 }
 
 export interface BlockLink extends Schema.Component {
-  collectionName: "components_block_links";
+  collectionName: 'components_block_links';
   info: {
-    displayName: "socialMediaLink";
-    description: "";
+    displayName: 'socialMediaLink';
+    description: '';
   };
   attributes: {
     name: Attribute.Enumeration<
       [
-        "x",
-        "instagram",
-        "tiktok",
-        "youtube",
-        "facebook",
-        "snapchat",
-        "linkedin"
+        'x',
+        'instagram',
+        'tiktok',
+        'youtube',
+        'facebook',
+        'snapchat',
+        'linkedin'
       ]
     > &
       Attribute.Required;
@@ -1025,25 +1025,25 @@ export interface BlockLink extends Schema.Component {
 }
 
 export interface BlockLatestNews extends Schema.Component {
-  collectionName: "components_block_latest_news";
+  collectionName: 'components_block_latest_news';
   info: {
-    displayName: "latestNews";
-    description: "";
+    displayName: 'latestNews';
+    description: '';
   };
   attributes: {
     title: Attribute.Text & Attribute.Required;
-    cta: Attribute.Component<"common.link"> & Attribute.Required;
+    cta: Attribute.Component<'common.link'> & Attribute.Required;
   };
 }
 
 export interface BlockKeyNumberCarousel extends Schema.Component {
-  collectionName: "components_block_key_number_carousels";
+  collectionName: 'components_block_key_number_carousels';
   info: {
-    displayName: "KeyNumberCarousel";
+    displayName: 'KeyNumberCarousel';
   };
   attributes: {
     title: Attribute.String;
-    items: Attribute.Component<"common.key-number-items", true> &
+    items: Attribute.Component<'common.key-number-items', true> &
       Attribute.SetMinMax<
         {
           max: 4;
@@ -1054,13 +1054,13 @@ export interface BlockKeyNumberCarousel extends Schema.Component {
 }
 
 export interface BlockImage extends Schema.Component {
-  collectionName: "components_block_images";
+  collectionName: 'components_block_images';
   info: {
-    displayName: "Image";
-    description: "";
+    displayName: 'Image';
+    description: '';
   };
   attributes: {
-    image: Attribute.Media<"images" | "files" | "videos" | "audios"> &
+    image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
       Attribute.Required;
     description: Attribute.Text;
     alt: Attribute.String & Attribute.Required;
@@ -1068,14 +1068,14 @@ export interface BlockImage extends Schema.Component {
 }
 
 export interface BlockImageText extends Schema.Component {
-  collectionName: "components_block_image_texts";
+  collectionName: 'components_block_image_texts';
   info: {
-    displayName: "ImageText";
-    description: "";
+    displayName: 'ImageText';
+    description: '';
   };
   attributes: {
     title: Attribute.String;
-    image: Attribute.Media<"images"> & Attribute.Required;
+    image: Attribute.Media<'images'> & Attribute.Required;
     isImageRight: Attribute.Boolean & Attribute.DefaultTo<true>;
     icon: Attribute.String;
     text: Attribute.Blocks & Attribute.Required;
@@ -1083,56 +1083,56 @@ export interface BlockImageText extends Schema.Component {
 }
 
 export interface BlockImageGallery extends Schema.Component {
-  collectionName: "components_block_image_galleries";
+  collectionName: 'components_block_image_galleries';
   info: {
-    displayName: "Image Gallery";
+    displayName: 'Image Gallery';
   };
   attributes: {
-    images: Attribute.Media<"images", true> & Attribute.Required;
+    images: Attribute.Media<'images', true> & Attribute.Required;
   };
 }
 
 export interface BlockHeader extends Schema.Component {
-  collectionName: "components_block_headers";
+  collectionName: 'components_block_headers';
   info: {
-    displayName: "Header";
-    description: "";
+    displayName: 'Header';
+    description: '';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
     text: Attribute.Text;
-    image: Attribute.Media<"images" | "files" | "videos" | "audios"> &
+    image: Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
       Attribute.Required;
     icon: Attribute.String & Attribute.Required;
-    cta: Attribute.Component<"common.link">;
+    cta: Attribute.Component<'common.link'>;
     icon2: Attribute.String;
     aboveTitle: Attribute.String;
   };
 }
 
 export interface BlockHeaderWithQRcode extends Schema.Component {
-  collectionName: "components_block_header_with_q_rcodes";
+  collectionName: 'components_block_header_with_q_rcodes';
   info: {
-    displayName: "HeaderWithQRcode";
-    description: "";
+    displayName: 'HeaderWithQRcode';
+    description: '';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
     text: Attribute.Text;
-    image: Attribute.Media<"images"> & Attribute.Required;
+    image: Attribute.Media<'images'> & Attribute.Required;
     icon: Attribute.String;
-    QRCode: Attribute.Component<"common.link">;
+    QRCode: Attribute.Component<'common.link'>;
   };
 }
 
 export interface BlockFaq extends Schema.Component {
-  collectionName: "components_block_faqs";
+  collectionName: 'components_block_faqs';
   info: {
-    displayName: "Faq";
+    displayName: 'Faq';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
-    cta: Attribute.Component<"common.link"> & Attribute.Required;
+    cta: Attribute.Component<'common.link'> & Attribute.Required;
     categories: Attribute.String;
     filteringProperty: Attribute.String & Attribute.Required;
     limit: Attribute.Integer & Attribute.Required & Attribute.DefaultTo<10>;
@@ -1140,15 +1140,15 @@ export interface BlockFaq extends Schema.Component {
 }
 
 export interface BlockExperienceVideoCarousel extends Schema.Component {
-  collectionName: "components_block_experience_video_carousels";
+  collectionName: 'components_block_experience_video_carousels';
   info: {
-    displayName: "ExperienceVideoCarousel";
-    description: "";
+    displayName: 'ExperienceVideoCarousel';
+    description: '';
   };
   attributes: {
     title: Attribute.String;
     carouselItems: Attribute.Component<
-      "common.experience-video-carousel-item",
+      'common.experience-video-carousel-item',
       true
     > &
       Attribute.Required;
@@ -1157,50 +1157,50 @@ export interface BlockExperienceVideoCarousel extends Schema.Component {
 }
 
 export interface BlockDoublePushCta extends Schema.Component {
-  collectionName: "components_block_double_push_ctas";
+  collectionName: 'components_block_double_push_ctas';
   info: {
-    displayName: "Push Grey CTA";
-    description: "";
+    displayName: 'Push Grey CTA';
+    description: '';
   };
   attributes: {
-    image: Attribute.Media<"images"> & Attribute.Required;
+    image: Attribute.Media<'images'> & Attribute.Required;
     title: Attribute.String & Attribute.Required;
     text: Attribute.Text;
-    firstCta: Attribute.Component<"common.link"> & Attribute.Required;
+    firstCta: Attribute.Component<'common.link'> & Attribute.Required;
     icon: Attribute.String;
-    secondCta: Attribute.Component<"common.not-required-link">;
+    secondCta: Attribute.Component<'common.not-required-link'>;
   };
 }
 
 export interface BlockDetailedLogos extends Schema.Component {
-  collectionName: "components_block_detailed_logos";
+  collectionName: 'components_block_detailed_logos';
   info: {
-    displayName: "Detailed Logos";
+    displayName: 'Detailed Logos';
   };
   attributes: {
     title: Attribute.String;
-    logos: Attribute.Component<"common.detailed-logo", true> &
+    logos: Attribute.Component<'common.detailed-logo', true> &
       Attribute.Required;
   };
 }
 
 export interface BlockColumnsText extends Schema.Component {
-  collectionName: "components_block_columns_texts";
+  collectionName: 'components_block_columns_texts';
   info: {
-    displayName: "Columns Text";
-    description: "";
+    displayName: 'Columns Text';
+    description: '';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
-    video: Attribute.Component<"block.video">;
-    columns: Attribute.Component<"common.simple-text-column", true>;
+    video: Attribute.Component<'block.video'>;
+    columns: Attribute.Component<'common.simple-text-column', true>;
   };
 }
 
 export interface BlockCenteredTitle extends Schema.Component {
-  collectionName: "components_block_centered_titles";
+  collectionName: 'components_block_centered_titles';
   info: {
-    displayName: "Centered Title";
+    displayName: 'Centered Title';
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
@@ -1208,10 +1208,10 @@ export interface BlockCenteredTitle extends Schema.Component {
 }
 
 export interface BlockCenteredText extends Schema.Component {
-  collectionName: "components_block_centered_texts";
+  collectionName: 'components_block_centered_texts';
   info: {
-    displayName: "Centered Text";
-    description: "";
+    displayName: 'Centered Text';
+    description: '';
   };
   attributes: {
     title: Attribute.String;
@@ -1220,93 +1220,93 @@ export interface BlockCenteredText extends Schema.Component {
 }
 
 export interface BlockBreadcrumb extends Schema.Component {
-  collectionName: "components_block_breadcrumbs";
+  collectionName: 'components_block_breadcrumbs';
   info: {
-    displayName: "Breadcrumbs";
-    description: "";
+    displayName: 'Breadcrumbs';
+    description: '';
   };
   attributes: {};
 }
 
-declare module "@strapi/types" {
+declare module '@strapi/types' {
   export module Shared {
     export interface Components {
-      "shared.seo": SharedSeo;
-      "shared.meta-social": SharedMetaSocial;
-      "simulator.success-screen": SimulatorSuccessScreen;
-      "simulator.step": SimulatorStep;
-      "simulator.radio-question": SimulatorRadioQuestion;
-      "simulator.failure-screen": SimulatorFailureScreen;
-      "simulator.answer": SimulatorAnswer;
-      "simulator.amount-screen": SimulatorAmountScreen;
-      "simulator.age-question": SimulatorAgeQuestion;
-      "header.navigation-items": HeaderNavigationItems;
-      "header.mega-menu": HeaderMegaMenu;
-      "header.login": HeaderLogin;
-      "header.login-items": HeaderLoginItems;
-      "header.header": HeaderHeader;
-      "header.account-item": HeaderAccountItem;
-      "header.account-dropdown": HeaderAccountDropdown;
-      "home.recommendations-section": HomeRecommendationsSection;
-      "home.hero-section": HomeHeroSection;
-      "home.eligibility-section": HomeEligibilitySection;
-      "home.eligibility-items": HomeEligibilityItems;
-      "footer.list": FooterList;
-      "footer.legal-links": FooterLegalLinks;
-      "common.vertical-carousel-item": CommonVerticalCarouselItem;
-      "common.simple-text-column": CommonSimpleTextColumn;
-      "common.piled-card-item": CommonPiledCardItem;
-      "common.person": CommonPerson;
-      "common.offers": CommonOffers;
-      "common.offers-carousel-item": CommonOffersCarouselItem;
-      "common.not-required-link": CommonNotRequiredLink;
-      "common.logo": CommonLogo;
-      "common.little-list-component": CommonLittleListComponent;
-      "common.link": CommonLink;
-      "common.key-number-items": CommonKeyNumberItems;
-      "common.filtre": CommonFiltre;
-      "common.experience-video-carousel-item": CommonExperienceVideoCarouselItem;
-      "common.detailed-logo": CommonDetailedLogo;
-      "block.video": BlockVideo;
-      "block.vertical-carousel": BlockVerticalCarousel;
-      "block.tabs-simple-text": BlockTabsSimpleText;
-      "block.tabs-push-grey-cta": BlockTabsPushGreyCta;
-      "block.tabs-little-list": BlockTabsLittleList;
-      "block.tabs-image-text": BlockTabsImageText;
-      "block.tab-simple-text": BlockTabSimpleText;
-      "block.tab-push-grey-cta": BlockTabPushGreyCta;
-      "block.tab-little-list": BlockTabLittleList;
-      "block.tab-image-text": BlockTabImageText;
-      "block.space": BlockSpace;
-      "block.social-media": BlockSocialMedia;
-      "block.simple-text-v2": BlockSimpleTextV2;
-      "block.simple-push-cta": BlockSimplePushCta;
-      "block.separator": BlockSeparator;
-      "block.related-news": BlockRelatedNews;
-      "block.push-cta": BlockPushCta;
-      "block.piled-cards": BlockPiledCards;
-      "block.organization-chart": BlockOrganizationChart;
-      "block.offers-section": BlockOffersSection;
-      "block.offers-carousel": BlockOffersCarousel;
-      "block.offer-list": BlockOfferList;
-      "block.logos": BlockLogos;
-      "block.little-list": BlockLittleList;
-      "block.link": BlockLink;
-      "block.latest-news": BlockLatestNews;
-      "block.key-number-carousel": BlockKeyNumberCarousel;
-      "block.image": BlockImage;
-      "block.image-text": BlockImageText;
-      "block.image-gallery": BlockImageGallery;
-      "block.header": BlockHeader;
-      "block.header-with-q-rcode": BlockHeaderWithQRcode;
-      "block.faq": BlockFaq;
-      "block.experience-video-carousel": BlockExperienceVideoCarousel;
-      "block.double-push-cta": BlockDoublePushCta;
-      "block.detailed-logos": BlockDetailedLogos;
-      "block.columns-text": BlockColumnsText;
-      "block.centered-title": BlockCenteredTitle;
-      "block.centered-text": BlockCenteredText;
-      "block.breadcrumb": BlockBreadcrumb;
+      'home.recommendations-section': HomeRecommendationsSection;
+      'home.hero-section': HomeHeroSection;
+      'home.eligibility-section': HomeEligibilitySection;
+      'home.eligibility-items': HomeEligibilityItems;
+      'simulator.success-screen': SimulatorSuccessScreen;
+      'simulator.step': SimulatorStep;
+      'simulator.radio-question': SimulatorRadioQuestion;
+      'simulator.failure-screen': SimulatorFailureScreen;
+      'simulator.answer': SimulatorAnswer;
+      'simulator.amount-screen': SimulatorAmountScreen;
+      'simulator.age-question': SimulatorAgeQuestion;
+      'shared.seo': SharedSeo;
+      'shared.meta-social': SharedMetaSocial;
+      'common.vertical-carousel-item': CommonVerticalCarouselItem;
+      'common.simple-text-column': CommonSimpleTextColumn;
+      'common.piled-card-item': CommonPiledCardItem;
+      'common.person': CommonPerson;
+      'common.offers': CommonOffers;
+      'common.offers-carousel-item': CommonOffersCarouselItem;
+      'common.not-required-link': CommonNotRequiredLink;
+      'common.logo': CommonLogo;
+      'common.little-list-component': CommonLittleListComponent;
+      'common.link': CommonLink;
+      'common.key-number-items': CommonKeyNumberItems;
+      'common.filtre': CommonFiltre;
+      'common.experience-video-carousel-item': CommonExperienceVideoCarouselItem;
+      'common.detailed-logo': CommonDetailedLogo;
+      'footer.list': FooterList;
+      'footer.legal-links': FooterLegalLinks;
+      'header.navigation-items': HeaderNavigationItems;
+      'header.mega-menu': HeaderMegaMenu;
+      'header.login': HeaderLogin;
+      'header.login-items': HeaderLoginItems;
+      'header.header': HeaderHeader;
+      'header.account-item': HeaderAccountItem;
+      'header.account-dropdown': HeaderAccountDropdown;
+      'block.video': BlockVideo;
+      'block.vertical-carousel': BlockVerticalCarousel;
+      'block.tabs-simple-text': BlockTabsSimpleText;
+      'block.tabs-push-grey-cta': BlockTabsPushGreyCta;
+      'block.tabs-little-list': BlockTabsLittleList;
+      'block.tabs-image-text': BlockTabsImageText;
+      'block.tab-simple-text': BlockTabSimpleText;
+      'block.tab-push-grey-cta': BlockTabPushGreyCta;
+      'block.tab-little-list': BlockTabLittleList;
+      'block.tab-image-text': BlockTabImageText;
+      'block.space': BlockSpace;
+      'block.social-media': BlockSocialMedia;
+      'block.simple-text-v2': BlockSimpleTextV2;
+      'block.simple-push-cta': BlockSimplePushCta;
+      'block.separator': BlockSeparator;
+      'block.related-news': BlockRelatedNews;
+      'block.push-cta': BlockPushCta;
+      'block.piled-cards': BlockPiledCards;
+      'block.organization-chart': BlockOrganizationChart;
+      'block.offers-section': BlockOffersSection;
+      'block.offers-carousel': BlockOffersCarousel;
+      'block.offer-list': BlockOfferList;
+      'block.logos': BlockLogos;
+      'block.little-list': BlockLittleList;
+      'block.link': BlockLink;
+      'block.latest-news': BlockLatestNews;
+      'block.key-number-carousel': BlockKeyNumberCarousel;
+      'block.image': BlockImage;
+      'block.image-text': BlockImageText;
+      'block.image-gallery': BlockImageGallery;
+      'block.header': BlockHeader;
+      'block.header-with-q-rcode': BlockHeaderWithQRcode;
+      'block.faq': BlockFaq;
+      'block.experience-video-carousel': BlockExperienceVideoCarousel;
+      'block.double-push-cta': BlockDoublePushCta;
+      'block.detailed-logos': BlockDetailedLogos;
+      'block.columns-text': BlockColumnsText;
+      'block.centered-title': BlockCenteredTitle;
+      'block.centered-text': BlockCenteredText;
+      'block.breadcrumb': BlockBreadcrumb;
     }
   }
 }

--- a/content_management_system/types/generated/contentTypes.d.ts
+++ b/content_management_system/types/generated/contentTypes.d.ts
@@ -1978,6 +1978,10 @@ export interface ApiSimulatorSimulator extends Schema.SingleType {
         number
       > &
       Attribute.DefaultTo<0.5>;
+    disableSimulator: Attribute.Boolean &
+      Attribute.Required &
+      Attribute.DefaultTo<false>;
+    disableText: Attribute.Text & Attribute.Required;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;

--- a/public_website/src/pages/simulateur.tsx
+++ b/public_website/src/pages/simulateur.tsx
@@ -12,6 +12,7 @@ import { SimulatorProps } from '@/types/props'
 import { APIResponseData } from '@/types/strapi'
 import { Breadcrumb } from '@/ui/components/breadcrumb/Breadcrumb'
 import { ContentWrapper } from '@/ui/components/ContentWrapper'
+import DisabledSimulator from '@/ui/components/simulator/DisabledSimulator'
 import { Simulator } from '@/ui/components/simulator/Simulator'
 import { Typo } from '@/ui/components/typographies'
 
@@ -36,6 +37,8 @@ export default function SimulatorPage(props: SimulatorProps) {
     bottomEmoji,
     socialMedias,
     offres,
+    disableSimulator,
+    disableText,
   } = props.data.attributes
 
   const memoSteps = useMemo(() => steps.map((s) => s.step), [steps])
@@ -47,22 +50,26 @@ export default function SimulatorPage(props: SimulatorProps) {
           <Title>{title}</Title>
           <Description>{description}</Description>
           <UnpaddedBreadcrumb />
-          <StyledSimulator
-            ageQuestion={ageQuestion}
-            nationnalityQuestion={nationnalityQuestion}
-            residencyQuestion={residencyQuestion}
-            successScreen={successScreen}
-            failureScreen={failureScreen}
-            steps={memoSteps}
-            tooYoungScreen={tooYoungScreen}
-            amountScreen15={amountScreen_15}
-            amountScreen16={amountScreen_16}
-            amountScreen17={amountScreen_17}
-            amountScreen18={amountScreen_18}
-            tooOldScreen={tooOldScreen}
-            topEmoji={topEmoji}
-            bottomEmoji={bottomEmoji}
-          />
+          {disableSimulator ? (
+            <DisabledSimulator disableText={disableText} />
+          ) : (
+            <StyledSimulator
+              ageQuestion={ageQuestion}
+              nationnalityQuestion={nationnalityQuestion}
+              residencyQuestion={residencyQuestion}
+              successScreen={successScreen}
+              failureScreen={failureScreen}
+              steps={memoSteps}
+              tooYoungScreen={tooYoungScreen}
+              amountScreen15={amountScreen_15}
+              amountScreen16={amountScreen_16}
+              amountScreen17={amountScreen_17}
+              amountScreen18={amountScreen_18}
+              tooOldScreen={tooOldScreen}
+              topEmoji={topEmoji}
+              bottomEmoji={bottomEmoji}
+            />
+          )}
         </Root>
         {!!offres && (
           <SimplePushCta

--- a/public_website/src/types/components.d.ts
+++ b/public_website/src/types/components.d.ts
@@ -1,5 +1,68 @@
 import type { Schema, Attribute } from '@strapi/strapi';
 
+export interface HomeRecommendationsSection extends Schema.Component {
+  collectionName: 'components_home_recommendations_sections';
+  info: {
+    displayName: 'recommendationsSection';
+  };
+  attributes: {
+    recommendations: Attribute.Component<'block.vertical-carousel'> &
+      Attribute.Required;
+    recommendationsBackendTag: Attribute.String & Attribute.Required;
+    cta: Attribute.Component<'common.link'> & Attribute.Required;
+  };
+}
+
+export interface HomeHeroSection extends Schema.Component {
+  collectionName: 'components_home_hero_sections';
+  info: {
+    displayName: 'heroSection';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.Text & Attribute.Required;
+    subTitle: Attribute.String & Attribute.Required;
+    cta: Attribute.Component<'common.link'> & Attribute.Required;
+    firstEmoji: Attribute.String & Attribute.Required;
+    secondEmoji: Attribute.String & Attribute.Required;
+    thirdEmoji: Attribute.String & Attribute.Required;
+    fourthEmoji: Attribute.String & Attribute.Required;
+    images: Attribute.Media<'images', true> & Attribute.Required;
+    fifthEmoji: Attribute.String & Attribute.Required;
+    sixthEmoji: Attribute.String & Attribute.Required;
+  };
+}
+
+export interface HomeEligibilitySection extends Schema.Component {
+  collectionName: 'components_home_eligibility_sections';
+  info: {
+    displayName: 'eligibilitySection';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    items: Attribute.Component<'home.eligibility-items', true> &
+      Attribute.Required;
+    cardTitle: Attribute.Text & Attribute.Required;
+    cardDescription: Attribute.String & Attribute.Required;
+    cardCta: Attribute.Component<'common.link'> & Attribute.Required;
+    firstEmoji: Attribute.String & Attribute.Required;
+    secondEmoji: Attribute.String & Attribute.Required;
+  };
+}
+
+export interface HomeEligibilityItems extends Schema.Component {
+  collectionName: 'components_home_eligibility_items';
+  info: {
+    displayName: 'eligibilityItems';
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    description: Attribute.String & Attribute.Required;
+    emoji: Attribute.String & Attribute.Required;
+  };
+}
+
 export interface SimulatorSuccessScreen extends Schema.Component {
   collectionName: 'components_simulator_success_screens';
   info: {
@@ -88,15 +151,7 @@ export interface SimulatorAgeQuestion extends Schema.Component {
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
-    answers: Attribute.Component<'simulator.answer', true> &
-      Attribute.Required &
-      Attribute.SetMinMax<
-        {
-          min: 6;
-          max: 6;
-        },
-        number
-      >;
+    answers: Attribute.Component<'simulator.answer', true> & Attribute.Required;
   };
 }
 
@@ -149,264 +204,6 @@ export interface SharedMetaSocial extends Schema.Component {
       }>;
     image: Attribute.Media<'images' | 'files' | 'videos'>;
   };
-}
-
-export interface HomeRecommendationsSection extends Schema.Component {
-  collectionName: 'components_home_recommendations_sections';
-  info: {
-    displayName: 'recommendationsSection';
-  };
-  attributes: {
-    recommendations: Attribute.Component<'block.vertical-carousel'> &
-      Attribute.Required;
-    recommendationsBackendTag: Attribute.String & Attribute.Required;
-    cta: Attribute.Component<'common.link'> & Attribute.Required;
-  };
-}
-
-export interface HomeHeroSection extends Schema.Component {
-  collectionName: 'components_home_hero_sections';
-  info: {
-    displayName: 'heroSection';
-    description: '';
-  };
-  attributes: {
-    title: Attribute.Text & Attribute.Required;
-    subTitle: Attribute.String & Attribute.Required;
-    cta: Attribute.Component<'common.link'> & Attribute.Required;
-    firstEmoji: Attribute.String & Attribute.Required;
-    secondEmoji: Attribute.String & Attribute.Required;
-    thirdEmoji: Attribute.String & Attribute.Required;
-    fourthEmoji: Attribute.String & Attribute.Required;
-    images: Attribute.Media<'images', true> & Attribute.Required;
-    fifthEmoji: Attribute.String & Attribute.Required;
-    sixthEmoji: Attribute.String & Attribute.Required;
-  };
-}
-
-export interface HomeEligibilitySection extends Schema.Component {
-  collectionName: 'components_home_eligibility_sections';
-  info: {
-    displayName: 'eligibilitySection';
-    description: '';
-  };
-  attributes: {
-    title: Attribute.String & Attribute.Required;
-    items: Attribute.Component<'home.eligibility-items', true> &
-      Attribute.Required;
-    cardTitle: Attribute.Text & Attribute.Required;
-    cardDescription: Attribute.String & Attribute.Required;
-    cardCta: Attribute.Component<'common.link'> & Attribute.Required;
-    firstEmoji: Attribute.String & Attribute.Required;
-    secondEmoji: Attribute.String & Attribute.Required;
-  };
-}
-
-export interface HomeEligibilityItems extends Schema.Component {
-  collectionName: 'components_home_eligibility_items';
-  info: {
-    displayName: 'eligibilityItems';
-  };
-  attributes: {
-    title: Attribute.String & Attribute.Required;
-    description: Attribute.String & Attribute.Required;
-    emoji: Attribute.String & Attribute.Required;
-  };
-}
-
-export interface HeaderNavigationItems extends Schema.Component {
-  collectionName: 'components_header_navigation_items';
-  info: {
-    displayName: 'navigationItems';
-  };
-  attributes: {
-    label: Attribute.String & Attribute.Required;
-    megaMenu: Attribute.Component<'header.mega-menu'>;
-  };
-}
-
-export interface HeaderMegaMenu extends Schema.Component {
-  collectionName: 'components_header_mega_menus';
-  info: {
-    displayName: 'megaMenu';
-    description: '';
-  };
-  attributes: {
-    title: Attribute.String & Attribute.Required;
-    primaryListItems: Attribute.Component<'common.link', true> &
-      Attribute.Required;
-    secondaryListItems: Attribute.Component<'common.link', true>;
-    cta: Attribute.Component<'common.link'> & Attribute.Required;
-    cardTitle: Attribute.String & Attribute.Required;
-    cardDescription: Attribute.String & Attribute.Required;
-    cardLink: Attribute.Component<'common.link'> & Attribute.Required;
-    bannerText: Attribute.String;
-    cardFirstEmoji: Attribute.String & Attribute.Required;
-    cardSecondEmoji: Attribute.String & Attribute.Required;
-    bannerAndroidUrl: Attribute.String;
-    bannerIosUrl: Attribute.String;
-    bannerDefaultUrl: Attribute.String;
-    theme: Attribute.Enumeration<
-      [
-        'purple',
-        'yellow',
-        'magenta',
-        'orange',
-        'green',
-        'gold',
-        'sky',
-        'lila',
-        'deeppink',
-        'aquamarine',
-        'lightgray',
-        'saumon'
-      ]
-    > &
-      Attribute.DefaultTo<'gold'>;
-  };
-}
-
-export interface HeaderLogin extends Schema.Component {
-  collectionName: 'components_header_logins';
-  info: {
-    displayName: 'login';
-  };
-  attributes: {
-    buttonLabel: Attribute.String & Attribute.Required;
-    loginItems: Attribute.Component<'header.login-items', true> &
-      Attribute.SetMinMax<
-        {
-          max: 2;
-        },
-        number
-      >;
-  };
-}
-
-export interface HeaderLoginItems extends Schema.Component {
-  collectionName: 'components_header_login_items';
-  info: {
-    displayName: 'loginItems';
-    description: '';
-  };
-  attributes: {
-    label: Attribute.String & Attribute.Required;
-    color: Attribute.String & Attribute.Required;
-    emoji: Attribute.String & Attribute.Required;
-    url: Attribute.String & Attribute.Required;
-    eventName: Attribute.Enumeration<
-      [
-        'goToSignUpNative',
-        'goToSignUpPro',
-        'goToLoginNative',
-        'goToLoginPro',
-        'downloadApp',
-        'goToFaqNative',
-        'goToFaqPro',
-        'contactSupport'
-      ]
-    >;
-    eventOrigin: Attribute.Enumeration<
-      [
-        'header',
-        'home',
-        'menu-young-people-and-parents',
-        'menu-pros',
-        'get-your-credit',
-        'essential-pros',
-        'how-to-propose-offers',
-        'help-young-people-and-parents',
-        'help-pros',
-        'help-teachers',
-        'simulator',
-        'parents',
-        'footer'
-      ]
-    >;
-  };
-}
-
-export interface HeaderHeader extends Schema.Component {
-  collectionName: 'components_header_headers';
-  info: {
-    displayName: 'header';
-  };
-  attributes: {};
-}
-
-export interface HeaderAccountItem extends Schema.Component {
-  collectionName: 'components_header_account_item';
-  info: {
-    displayName: 'accountItem';
-    description: '';
-  };
-  attributes: {
-    label: Attribute.String & Attribute.Required;
-    color: Attribute.String & Attribute.Required;
-    emoji: Attribute.String & Attribute.Required;
-    url: Attribute.String & Attribute.Required;
-    eventName: Attribute.Enumeration<
-      [
-        'goToSignUpNative',
-        'goToSignUpPro',
-        'goToLoginNative',
-        'goToLoginPro',
-        'downloadApp',
-        'goToFaqNative',
-        'goToFaqPro',
-        'contactSupport'
-      ]
-    >;
-    eventOrigin: Attribute.Enumeration<
-      [
-        'header',
-        'home',
-        'menu-young-people-and-parents',
-        'menu-pros',
-        'get-your-credit',
-        'essential-pros',
-        'how-to-propose-offers',
-        'help-young-people-and-parents',
-        'help-pros',
-        'help-teachers',
-        'simulator',
-        'parents',
-        'footer'
-      ]
-    >;
-  };
-}
-
-export interface HeaderAccountDropdown extends Schema.Component {
-  collectionName: 'components_header_account_dropdowns';
-  info: {
-    displayName: 'accountDropdown';
-  };
-  attributes: {
-    buttonLabel: Attribute.String & Attribute.Required;
-    items: Attribute.Component<'header.account-item', true> &
-      Attribute.Required;
-  };
-}
-
-export interface FooterList extends Schema.Component {
-  collectionName: 'components_footer_lists';
-  info: {
-    displayName: 'Lists';
-    description: '';
-  };
-  attributes: {
-    Title: Attribute.String & Attribute.Required;
-    Links: Attribute.Component<'common.link', true>;
-  };
-}
-
-export interface FooterLegalLinks extends Schema.Component {
-  collectionName: 'components_footer_legal_links';
-  info: {
-    displayName: 'LegalLinks';
-  };
-  attributes: {};
 }
 
 export interface CommonVerticalCarouselItem extends Schema.Component {
@@ -685,6 +482,201 @@ export interface CommonDetailedLogo extends Schema.Component {
     description: Attribute.String & Attribute.Required;
     cta: Attribute.Component<'common.link'> & Attribute.Required;
     image: Attribute.Media<'images'> & Attribute.Required;
+  };
+}
+
+export interface FooterList extends Schema.Component {
+  collectionName: 'components_footer_lists';
+  info: {
+    displayName: 'Lists';
+    description: '';
+  };
+  attributes: {
+    Title: Attribute.String & Attribute.Required;
+    Links: Attribute.Component<'common.link', true>;
+  };
+}
+
+export interface FooterLegalLinks extends Schema.Component {
+  collectionName: 'components_footer_legal_links';
+  info: {
+    displayName: 'LegalLinks';
+  };
+  attributes: {};
+}
+
+export interface HeaderNavigationItems extends Schema.Component {
+  collectionName: 'components_header_navigation_items';
+  info: {
+    displayName: 'navigationItems';
+  };
+  attributes: {
+    label: Attribute.String & Attribute.Required;
+    megaMenu: Attribute.Component<'header.mega-menu'>;
+  };
+}
+
+export interface HeaderMegaMenu extends Schema.Component {
+  collectionName: 'components_header_mega_menus';
+  info: {
+    displayName: 'megaMenu';
+    description: '';
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    primaryListItems: Attribute.Component<'common.link', true> &
+      Attribute.Required;
+    secondaryListItems: Attribute.Component<'common.link', true>;
+    cta: Attribute.Component<'common.link'> & Attribute.Required;
+    cardTitle: Attribute.String & Attribute.Required;
+    cardDescription: Attribute.String & Attribute.Required;
+    cardLink: Attribute.Component<'common.link'> & Attribute.Required;
+    bannerText: Attribute.String;
+    cardFirstEmoji: Attribute.String & Attribute.Required;
+    cardSecondEmoji: Attribute.String & Attribute.Required;
+    bannerAndroidUrl: Attribute.String;
+    bannerIosUrl: Attribute.String;
+    bannerDefaultUrl: Attribute.String;
+    theme: Attribute.Enumeration<
+      [
+        'purple',
+        'yellow',
+        'magenta',
+        'orange',
+        'green',
+        'gold',
+        'sky',
+        'lila',
+        'deeppink',
+        'aquamarine',
+        'lightgray',
+        'saumon'
+      ]
+    > &
+      Attribute.DefaultTo<'gold'>;
+  };
+}
+
+export interface HeaderLogin extends Schema.Component {
+  collectionName: 'components_header_logins';
+  info: {
+    displayName: 'login';
+  };
+  attributes: {
+    buttonLabel: Attribute.String & Attribute.Required;
+    loginItems: Attribute.Component<'header.login-items', true> &
+      Attribute.SetMinMax<
+        {
+          max: 2;
+        },
+        number
+      >;
+  };
+}
+
+export interface HeaderLoginItems extends Schema.Component {
+  collectionName: 'components_header_login_items';
+  info: {
+    displayName: 'loginItems';
+    description: '';
+  };
+  attributes: {
+    label: Attribute.String & Attribute.Required;
+    color: Attribute.String & Attribute.Required;
+    emoji: Attribute.String & Attribute.Required;
+    url: Attribute.String & Attribute.Required;
+    eventName: Attribute.Enumeration<
+      [
+        'goToSignUpNative',
+        'goToSignUpPro',
+        'goToLoginNative',
+        'goToLoginPro',
+        'downloadApp',
+        'goToFaqNative',
+        'goToFaqPro',
+        'contactSupport'
+      ]
+    >;
+    eventOrigin: Attribute.Enumeration<
+      [
+        'header',
+        'home',
+        'menu-young-people-and-parents',
+        'menu-pros',
+        'get-your-credit',
+        'essential-pros',
+        'how-to-propose-offers',
+        'help-young-people-and-parents',
+        'help-pros',
+        'help-teachers',
+        'simulator',
+        'parents',
+        'footer'
+      ]
+    >;
+  };
+}
+
+export interface HeaderHeader extends Schema.Component {
+  collectionName: 'components_header_headers';
+  info: {
+    displayName: 'header';
+  };
+  attributes: {};
+}
+
+export interface HeaderAccountItem extends Schema.Component {
+  collectionName: 'components_header_account_item';
+  info: {
+    displayName: 'accountItem';
+    description: '';
+  };
+  attributes: {
+    label: Attribute.String & Attribute.Required;
+    color: Attribute.String & Attribute.Required;
+    emoji: Attribute.String & Attribute.Required;
+    url: Attribute.String & Attribute.Required;
+    eventName: Attribute.Enumeration<
+      [
+        'goToSignUpNative',
+        'goToSignUpPro',
+        'goToLoginNative',
+        'goToLoginPro',
+        'downloadApp',
+        'goToFaqNative',
+        'goToFaqPro',
+        'contactSupport'
+      ]
+    >;
+    eventOrigin: Attribute.Enumeration<
+      [
+        'header',
+        'home',
+        'menu-young-people-and-parents',
+        'menu-pros',
+        'get-your-credit',
+        'essential-pros',
+        'how-to-propose-offers',
+        'help-young-people-and-parents',
+        'help-pros',
+        'help-teachers',
+        'simulator',
+        'parents',
+        'footer'
+      ]
+    >;
+  };
+}
+
+export interface HeaderAccountDropdown extends Schema.Component {
+  collectionName: 'components_header_account_dropdowns';
+  info: {
+    displayName: 'accountDropdown';
+  };
+  attributes: {
+    buttonLabel: Attribute.String & Attribute.Required;
+    items: Attribute.Component<'header.account-item', true> &
+      Attribute.Required;
   };
 }
 
@@ -1239,6 +1231,10 @@ export interface BlockBreadcrumb extends Schema.Component {
 declare module '@strapi/types' {
   export module Shared {
     export interface Components {
+      'home.recommendations-section': HomeRecommendationsSection;
+      'home.hero-section': HomeHeroSection;
+      'home.eligibility-section': HomeEligibilitySection;
+      'home.eligibility-items': HomeEligibilityItems;
       'simulator.success-screen': SimulatorSuccessScreen;
       'simulator.step': SimulatorStep;
       'simulator.radio-question': SimulatorRadioQuestion;
@@ -1248,19 +1244,6 @@ declare module '@strapi/types' {
       'simulator.age-question': SimulatorAgeQuestion;
       'shared.seo': SharedSeo;
       'shared.meta-social': SharedMetaSocial;
-      'home.recommendations-section': HomeRecommendationsSection;
-      'home.hero-section': HomeHeroSection;
-      'home.eligibility-section': HomeEligibilitySection;
-      'home.eligibility-items': HomeEligibilityItems;
-      'header.navigation-items': HeaderNavigationItems;
-      'header.mega-menu': HeaderMegaMenu;
-      'header.login': HeaderLogin;
-      'header.login-items': HeaderLoginItems;
-      'header.header': HeaderHeader;
-      'header.account-item': HeaderAccountItem;
-      'header.account-dropdown': HeaderAccountDropdown;
-      'footer.list': FooterList;
-      'footer.legal-links': FooterLegalLinks;
       'common.vertical-carousel-item': CommonVerticalCarouselItem;
       'common.simple-text-column': CommonSimpleTextColumn;
       'common.piled-card-item': CommonPiledCardItem;
@@ -1275,6 +1258,15 @@ declare module '@strapi/types' {
       'common.filtre': CommonFiltre;
       'common.experience-video-carousel-item': CommonExperienceVideoCarouselItem;
       'common.detailed-logo': CommonDetailedLogo;
+      'footer.list': FooterList;
+      'footer.legal-links': FooterLegalLinks;
+      'header.navigation-items': HeaderNavigationItems;
+      'header.mega-menu': HeaderMegaMenu;
+      'header.login': HeaderLogin;
+      'header.login-items': HeaderLoginItems;
+      'header.header': HeaderHeader;
+      'header.account-item': HeaderAccountItem;
+      'header.account-dropdown': HeaderAccountDropdown;
       'block.video': BlockVideo;
       'block.vertical-carousel': BlockVerticalCarousel;
       'block.tabs-simple-text': BlockTabsSimpleText;

--- a/public_website/src/types/contentTypes.d.ts
+++ b/public_website/src/types/contentTypes.d.ts
@@ -1978,6 +1978,10 @@ export interface ApiSimulatorSimulator extends Schema.SingleType {
         number
       > &
       Attribute.DefaultTo<0.5>;
+    disableSimulator: Attribute.Boolean &
+      Attribute.Required &
+      Attribute.DefaultTo<false>;
+    disableText: Attribute.Text & Attribute.Required;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;

--- a/public_website/src/ui/components/simulator/DisabledSimulator.tsx
+++ b/public_website/src/ui/components/simulator/DisabledSimulator.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import styled, { css } from 'styled-components'
+
+import { Typo } from '../typographies'
+
+const SimulatorWrapper = styled.div`
+  ${({ theme }) => css`
+    background: white;
+    border-radius: ${theme.radius.sm};
+    padding: 2rem;
+    box-shadow: ${theme.shadows.popover};
+    text-align: center;
+    max-width: 800px;
+    margin: 2rem auto;
+    position: relative;
+  `}
+`
+
+const Emoji = styled.span`
+  ${({ theme }) => css`
+    font-size: ${theme.fonts.sizes['6xl']};
+    position: absolute;
+    right: -10px;
+    top: -10px;
+    transform: rotate(15deg);
+  `}
+`
+
+type DisabledSimulatorProps = {
+  disableText: string
+}
+export default function DisabledSimulator({
+  disableText,
+}: DisabledSimulatorProps) {
+  return (
+    <SimulatorWrapper>
+      <Emoji>✌️</Emoji>
+      <Typo.Body>{disableText}</Typo.Body>
+    </SimulatorWrapper>
+  )
+}


### PR DESCRIPTION
## Contexte
Cette Pull Request introduit une nouvelle fonctionnalité qui permet de désactiver le simulateur dans l’application. Ce mécanisme est utile pour gérer l’activation ou la désactivation du simulateur directement via le CMS, et adapter l’affichage sur le site public en conséquence.

## Modifications Apportées

- **CMS / API Simulator** :
  - **Schéma du simulateur** :  
    Le fichier `schema.json` a été mis à jour pour inclure deux nouvelles propriétés :
    - `disableSimulator` : de type `boolean`, avec une valeur par défaut à `false` et marquée comme obligatoire.
    - `disableText` : de type `text` et obligatoire, permettant d’afficher un message personnalisé lorsque le simulateur est désactivé.

- **Site Public** :
  - **Page du simulateur** :  
    La page `simulateur.tsx` a été modifiée pour prendre en compte l’état désactivé du simulateur.
  - **Composant dédié** :  
    Un nouveau composant `DisabledSimulator.tsx` a été ajouté pour gérer l’affichage spécifique lorsque le simulateur est désactivé.
  - **Mise à jour des types** :  
    Les types associés, dans `components.d.ts` et `contentTypes.d.ts`, ont été ajustés afin d’assurer la cohérence avec la nouvelle fonctionnalité.

- **Workflow de Déploiement** :
  - Le workflow GitHub Actions défini dans `.github/workflows/on_dispatch_deploy_cms_production.yml` a été ajouté afin de pouvoir déployer en production uniquement le CMS sans déployer le site institutionnel.

<img width="1728" alt="Capture d’écran 2025-02-26 à 17 10 29" src="https://github.com/user-attachments/assets/8538200e-6993-4a50-9c55-fb69ad75d409" />
