### PR TITLE
feat(robots): add robots to disable seo for testing

### DIFF
--- a/.github/workflows/reusable_public_site_deploy.yml
+++ b/.github/workflows/reusable_public_site_deploy.yml
@@ -103,6 +103,9 @@ jobs:
         run: |
           kubectl port-forward --namespace ${{ inputs.namespace }} service/site-instit-cms 1337:1337 &
           yarn install
+          if [ "${{ inputs.environment }}" = "testing" ]; then
+            cp testing-robots.txt public/robots.txt
+          fi
           yarn build
 
       - name: "Setup firebase"

--- a/public_website/testing-robots.txt
+++ b/public_website/testing-robots.txt
@@ -1,0 +1,3 @@
+# https://www.robotstxt.org/robotstxt.html
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## Désactiver l’indexation SEO en environnement de test

### Contexte
Notre site de testing ne doit **pas** être indexé par les moteurs de recherche pour éviter le référencement de contenu non-prod.

### Ce que fait la PR
- Ajoute un `robots.txt` dédié qui interdit l’accès à tous les robots lorsque l’environnement est `testing`.
- Modifie le workflow de déploiement pour copier ce fichier de test en tant que `public/robots.txt` **uniquement** lors des builds sur l’environnement `testing`.

### Impact
- **Uniquement** sur l’environnement de test : le site ne sera pas indexé.  
- L’environnement de production n’est **pas** affecté.